### PR TITLE
Update bucklescript installation docs

### DIFF
--- a/documentation/docs/installation-on-bucklescript.md
+++ b/documentation/docs/installation-on-bucklescript.md
@@ -10,8 +10,11 @@ yarn add @reasonml-community/graphql-ppx@next --dev
 npm install @reasonml-community/graphql-ppx@next  --saveDev
 ```
 
-Second, add it to `ppx-flags` in your `bsconfig.json`:
+Second, add it to `ppx-flags` and `dependencies` in your `bsconfig.json`:
 
 ```json
+"bs-dependencies": [
+  "@reasonml-community/graphql-ppx"
+],
 "ppx-flags": ["@reasonml-community/graphql-ppx/ppx"]
 ```


### PR DESCRIPTION
When using fragments inside of fragments, `graphql-ppx` looks for an internal utility file `GraphQL_PPX` but I couldn't find this referenced anywhere in the docs. I think this would be a good place to add that you need to include the module in the bs-dependencies.