### PR TITLE
Move bs-platform into peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,13 @@
   "scripts": {
     "postinstall": "node ./copyPlatformBinaryInPlace.js"
   },
+  "devDependencies": {
+    "bs-platform": "^7.3.2"
+  },
+  "peerDependencies": {
+    "bs-platform": "^7.3.2"
+  },
   "publishConfig": {
     "access": "public"
-  },
-  "dependencies": {
-    "bs-platform": "^7.3.2"
   }
 }


### PR DESCRIPTION
When adding `graphql-ppx` to the `bs-dependencies` in `bsconfig.json` you'll get a duplicate package warning due to `graphql-ppx` also containing `bs-platform` as a dependency.

Moving `bs-platform` to be a `peerDependency` fixes this issue.