### PR TITLE
Fix bsconfig name prop

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -1,5 +1,5 @@
 {
-  "name": "graphql-ppx",
+  "name": "@reasonml-community/graphql-ppx",
   "refmt": 3,
   "package-specs": {
     "module": "es6",


### PR DESCRIPTION
When this module is listed as a bs-dependency and is actually required by a file (for example, when merging fragments) you would get a runtime error when that code is hit because the name of the bs package is not the same as the name of the npm package.