### PR TITLE
chore(native): remove refmterr from build-command

### DIFF
--- a/esy.json
+++ b/esy.json
@@ -22,7 +22,7 @@
     "@opam/ocaml-lsp-server": "ocaml/ocaml-lsp:ocaml-lsp-server.opam#a83bd09"
   },
   "esy": {
-    "build": [["refmterr", "dune", "build", "-p", "#{self.name}"]],
+    "build": [["dune", "build", "-p", "#{self.name}"]],
     "buildDev": [["refmterr", "dune", "build"]],
     "buildsInSource": "_build"
   }


### PR DESCRIPTION
Looks like `refmterr` snuck in there again!