### PR TITLE
Support `ppxAs` in fragment spreads

### DIFF
--- a/src/base/extract_type_definitions.re
+++ b/src/base/extract_type_definitions.re
@@ -146,7 +146,7 @@ let rec extract = (~variant=false, ~path, ~raw) =>
       ...extract_fragments(fragments, path, raw),
     ]
   | Res_custom_decoder(_loc, _ident, inner) => extract(~path, ~raw, inner)
-  | Res_solo_fragment_spread(_loc, _name, _) => []
+  | Res_solo_fragment_spread(_) => []
   | Res_error(_loc, _message) => []
   | Res_id(_loc) => []
   | Res_string(_loc) => []

--- a/src/base/result_decoder.re
+++ b/src/base/result_decoder.re
@@ -681,6 +681,7 @@ and unify_selection_set =
         config.map_loc(span),
         fs_name.item,
         arguments,
+        existing_record,
       );
     };
   | Some({item, _}) when as_record =>

--- a/src/base/result_structure.re
+++ b/src/base/result_structure.re
@@ -36,7 +36,7 @@ and t =
       bool,
     )
   | Res_poly_variant_interface(loc, string, (string, t), list((string, t)))
-  | Res_solo_fragment_spread(loc, string, list(string))
+  | Res_solo_fragment_spread(loc, string, list(string), option(string))
   | Res_error(loc, string);
 
 type definition =
@@ -71,7 +71,7 @@ let res_loc =
   | Res_poly_variant_selection_set(loc, _, _)
   | Res_poly_variant_union(loc, _, _, _, _)
   | Res_poly_variant_interface(loc, _, _, _)
-  | Res_solo_fragment_spread(loc, _, _)
+  | Res_solo_fragment_spread(loc, _, _, _)
   | Res_error(loc, _) => loc;
 
 let can_be_absent_as_field =

--- a/src/base/result_structure.rei
+++ b/src/base/result_structure.rei
@@ -36,7 +36,7 @@ and t =
       bool,
     )
   | Res_poly_variant_interface(loc, string, (string, t), list((string, t)))
-  | Res_solo_fragment_spread(loc, string, list(string))
+  | Res_solo_fragment_spread(loc, string, list(string), option(string))
   | Res_error(loc, string);
 
 type definition =

--- a/src/bucklescript/output_bucklescript_parser.re
+++ b/src/bucklescript/output_bucklescript_parser.re
@@ -151,8 +151,7 @@ let generate_poly_enum_decoder = (loc, enum_meta, omit_future_value) => {
   [%e match_expr];
 };
 
-let generate_fragment_parse_fun =
-    (config, loc, name, arguments, definition, _existing_record) => {
+let generate_fragment_parse_fun = (config, loc, name, arguments, definition) => {
   open Ast_helper;
   let ident =
     Ast_helper.Exp.ident({
@@ -199,15 +198,8 @@ let generate_fragment_parse_fun =
 };
 
 let generate_solo_fragment_spread_decoder =
-    (config, loc, name, arguments, definition, existing_record) => {
-  generate_fragment_parse_fun(
-    config,
-    loc,
-    name,
-    arguments,
-    definition,
-    existing_record,
-  );
+    (config, loc, name, arguments, definition) => {
+  generate_fragment_parse_fun(config, loc, name, arguments, definition);
 };
 
 let generate_error = (loc, message) => {
@@ -322,7 +314,6 @@ and generate_object_decoder =
             name,
             arguments,
             definition,
-            None,
           );
         };
 
@@ -699,13 +690,12 @@ and generate_parser = (config, path: list(string), definition) =>
       [name, ...path],
       definition,
     )
-  | Res_solo_fragment_spread(loc, name, arguments, existing_record) =>
+  | Res_solo_fragment_spread(loc, name, arguments, _existing_record) =>
     generate_solo_fragment_spread_decoder(
       config,
       loc,
       name,
       arguments,
       definition,
-      existing_record,
     )
   | Res_error(loc, message) => generate_error(loc, message);

--- a/src/bucklescript/output_bucklescript_types.re
+++ b/src/bucklescript/output_bucklescript_types.re
@@ -83,9 +83,7 @@ let rec generate_type = (~atLoc=?, config, path, raw) =>
     }
   | Res_solo_fragment_spread(loc, module_name, _arguments, type_name) =>
     switch (type_name, raw) {
-    | (Some(type_name), false) =>
-      Format.eprintf("output types %s %s???@.", module_name, type_name);
-      base_type(~loc=conv_loc(loc), type_name);
+    | (Some(type_name), false) => base_type(~loc=conv_loc(loc), type_name)
     | (_, false) => base_type(~loc=conv_loc(loc), module_name ++ ".t")
     | (_, true) => base_type(~loc=conv_loc(loc), module_name ++ ".Raw.t")
     }

--- a/src/bucklescript/output_bucklescript_types.re
+++ b/src/bucklescript/output_bucklescript_types.re
@@ -81,11 +81,13 @@ let rec generate_type = (~atLoc=?, config, path, raw) =>
   | Res_poly_variant_interface(_loc, _name, _, _) => {
       base_type(~loc=?atLoc, generate_type_name(path));
     }
-  | Res_solo_fragment_spread(loc, module_name, _arguments) =>
-    if (raw) {
-      base_type(~loc=conv_loc(loc), module_name ++ ".Raw.t");
-    } else {
-      base_type(~loc=conv_loc(loc), module_name ++ ".t");
+  | Res_solo_fragment_spread(loc, module_name, _arguments, type_name) =>
+    switch (type_name, raw) {
+    | (Some(type_name), false) =>
+      Format.eprintf("output types %s %s???@.", module_name, type_name);
+      base_type(~loc=conv_loc(loc), type_name);
+    | (_, false) => base_type(~loc=conv_loc(loc), module_name ++ ".t")
+    | (_, true) => base_type(~loc=conv_loc(loc), module_name ++ ".Raw.t")
     }
   | Res_error(loc, error) =>
     raise(Location.Error(Location.error(~loc=conv_loc(loc), error)))

--- a/src/native/output_native_decoder.re
+++ b/src/native/output_native_decoder.re
@@ -194,7 +194,7 @@ let rec generate_decoder = config =>
       base,
       fragments,
     )
-  | Res_solo_fragment_spread(loc, name, _arguments) =>
+  | Res_solo_fragment_spread(loc, name, _arguments, _existing_record) =>
     generate_solo_fragment_spread(conv_loc(loc), name)
   | Res_error(loc, message) => generate_error(conv_loc(loc), message)
 and generate_nullable_decoder = (config, loc, inner) =>

--- a/tests_bucklescript/operations/union.re
+++ b/tests_bucklescript/operations/union.re
@@ -51,15 +51,13 @@ module NamedQuery = [%graphql
 
 module NamedSpread = [%graphql
   {|
-  {
-    fragment DogFields on Dog {
-      name
-    }
+  fragment DogFields on Dog {
+    name
+  }
 
-    query dogOrHuman {
-      ...on Dog @ppxAs(type: "named") {
-        name
-      }
+  query dogOrHuman {
+    ...on Dog @ppxAs(type: "named") {
+      ...DogFields
     }
   }
 |}

--- a/tests_bucklescript/operations/union.re
+++ b/tests_bucklescript/operations/union.re
@@ -48,3 +48,19 @@ module NamedQuery = [%graphql
   }
 |}
 ];
+
+module NamedSpread = [%graphql
+  {|
+  {
+    fragment DogFields on Dog {
+      name
+    }
+
+    query dogOrHuman {
+      ...on Dog @ppxAs(type: "named") {
+        name
+      }
+    }
+  }
+|}
+];

--- a/tests_bucklescript/operations/union.re
+++ b/tests_bucklescript/operations/union.re
@@ -56,8 +56,10 @@ module NamedSpread = [%graphql
   }
 
   query dogOrHuman {
-    ...on Dog @ppxAs(type: "named") {
-      ...DogFields
+    dogOrHuman {
+      ...on Dog @ppxAs(type: "named") {
+        ...DogFields
+      }
     }
   }
 |}


### PR DESCRIPTION
This is similar to #167 and generalizes it to fragment spreads. It's useful to share a pre-existing type across many spreads of that fragment.