### PR TITLE
Allow passing an absolute path to the schema file

### DIFF
--- a/src/base/read_schema.re
+++ b/src/base/read_schema.re
@@ -282,17 +282,25 @@ let make_schema_meta = v =>
     }
   );
 
-let rec find_file_towards_root = (dir, file) => {
-  let here_file = Filename.concat(dir, file);
-  Log.log("[read_schema][here_file] " ++ here_file);
+let find_file_towards_root = (dir, file) => {
+  let rec inner = (dir, file) => {
+    let here_file = Filename.concat(dir, file);
+    Log.log("[read_schema][here_file] " ++ here_file);
 
-  if (Sys.file_exists(here_file)) {
-    let () = Log.log("[read_schema][found] " ++ here_file);
-    Some(here_file);
-  } else if (Filename.dirname(dir) == dir) {
-    None;
+    if (Sys.file_exists(here_file)) {
+      let () = Log.log("[read_schema][found] " ++ here_file);
+      Some(here_file);
+    } else if (Filename.dirname(dir) == dir) {
+      None;
+    } else {
+      inner(Filename.dirname(dir), file);
+    };
+  };
+
+  if (!Filename.is_relative(file)) {
+    Some(file);
   } else {
-    find_file_towards_root(Filename.dirname(dir), file);
+    inner(dir, file);
   };
 };
 


### PR DESCRIPTION
Because of dune's project root resolution, sometimes the schema file isn't where the PPX expects.