### PR TITLE
Don't use @next version

### DIFF
--- a/documentation/docs/installation-on-bucklescript.md
+++ b/documentation/docs/installation-on-bucklescript.md
@@ -5,9 +5,9 @@ title: Installation on Bucklescript
 First, add it to you dependencies using `npm` or `yarn`:
 
 ```sh
-yarn add @reasonml-community/graphql-ppx@next --dev
+yarn add @reasonml-community/graphql-ppx --dev
 # or
-npm install @reasonml-community/graphql-ppx@next  --saveDev
+npm install @reasonml-community/graphql-ppx --saveDev
 ```
 
 Second, add it to `ppx-flags` and `dependencies` in your `bsconfig.json`:


### PR DESCRIPTION
First of all, thank you.

I have installed this library following the docs, but with the @next version I have a lot of problem. After one hour I discovered that it isn't the stable version.

I think that would be great if docs propose to install the stable version 👍 