### PR TITLE
Introduce test for interface fragment on object type

### DIFF
--- a/graphql_schema.json
+++ b/graphql_schema.json
@@ -591,6 +591,30 @@
               "deprecationReason": null
             },
             {
+              "name": "admins",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "LIST",
+                  "name": null,
+                  "ofType": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "OBJECT",
+                      "name": "AdminUser",
+                      "ofType": null
+                    }
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "post",
               "description": null,
               "args": [],

--- a/tests_bucklescript/operations/interfaceFragmentOnObjectWithFieldDuplication.re
+++ b/tests_bucklescript/operations/interfaceFragmentOnObjectWithFieldDuplication.re
@@ -1,0 +1,25 @@
+module GraphQL_PPX = {
+  // mock
+  let deepMerge = (json1, _) => {
+    json1;
+  };
+};
+
+module UserData = [%graphql
+  {|
+    fragment UserData on User {
+      id
+    }
+  |};
+];
+
+module MyQuery = [%graphql
+  {|
+    query {
+      admins {
+        id
+        ...UserData
+      }
+    }
+  |}
+];


### PR DESCRIPTION
If interface A is implemented by object B then a fragment F on A should be
spreadable on a field returning object B. This is described in the spec
under [section
5.5.2.3.1](https://spec.graphql.org/June2018/#sec-Abstract-Spreads-in-Object-Scope).

This test shows that this fails if a field from the fragment is also selected
in the top level selection. This is a valid use-case when a component lower
in the tree requires the data and the component making the query does too.