### PR TITLE
Update version number for #284

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonml-community/graphql-ppx",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "graphql-ppx rewriter for ReScript/ReasonML",
   "repository": "https://github.com/reasonml-community/graphql-ppx",
   "author": "Tomasz Cichocinski <tomaszcichocinski@gmail.com>",


### PR DESCRIPTION
The code in this repository supports the latest version of rescript, which is 10, but the npm version has not been updated because the version number has not changed.