### PR TITLE
Switch to impl/intf from preprocess_*

### DIFF
--- a/src/ppx/graphql_ppx.ml
+++ b/src/ppx/graphql_ppx.ml
@@ -1101,5 +1101,5 @@ let args =
 
 let () =
   List.iter (fun (k, spec, doc) -> Ppxlib.Driver.add_arg k spec ~doc) args;
-  Ppxlib.Driver.register_transformation ~preprocess_impl:structure_mapper
-    ~preprocess_intf:signature_mapper "graphql"
+  Ppxlib.Driver.register_transformation ~impl:structure_mapper
+    ~intf:signature_mapper "graphql"


### PR DESCRIPTION
check the different ppxlib preprocessing phases: https://twitter.com/_anmonteiro/status/1644031054544789504

we want to run graphql_ppx in the "global transformations" phase, in order to allow graphql_ppx to be used with other PPXes that use the `preprocess` phase.