### PR TITLE
Fix Uncurried Fragment module signature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ _esy
 .merlin
 node_modules
 _build
+_opam
 _release
 *.byte
 *.native

--- a/snapshot_tests/operations/expected/apollo/generate/argNamedQuery.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/argNamedQuery.res.txt
@@ -42,9 +42,9 @@ argNamedQuery(query: $query)
     }
     {argNamedQuery: argNamedQuery}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    query: (a => a)((inp: t_variables).query),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {query: (a => a)((inp: t_variables).query)}: t_variables => Raw.t_variables
+  )
   let makeVariables = (~query, ()): t_variables => {query: query}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"
@@ -95,9 +95,9 @@ argNamedQuery(query: $query)
       }
       {argNamedQuery: argNamedQuery}
     }
-    let serializeVariables: t_variables => Raw.t_variables = inp => {
-      query: (a => a)((inp: t_variables).query),
-    }
+    let serializeVariables: t_variables => Raw.t_variables = (
+      inp => {query: (a => a)((inp: t_variables).query)}: t_variables => Raw.t_variables
+    )
     let makeVariables = (~query, ()): t_variables => {query: query}
     external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
     external toJson: Raw.t => Js.Json.t = "%identity"
@@ -147,9 +147,9 @@ argNamedQuery(query: $query)
       }
       {argNamedQuery: argNamedQuery}
     }
-    let serializeVariables: t_variables => Raw.t_variables = inp => {
-      query: (a => a)((inp: t_variables).query),
-    }
+    let serializeVariables: t_variables => Raw.t_variables = (
+      inp => {query: (a => a)((inp: t_variables).query)}: t_variables => Raw.t_variables
+    )
     let makeVariables = (~query, ()): t_variables => {query: query}
     external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
     external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/apollo/generate/comment.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/comment.res.txt
@@ -90,95 +90,101 @@ nonrecursiveInput(arg: $arg)
     }
     {nonrecursiveInput: nonrecursiveInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = inp => {
-    nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
-    nullableArray: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).nullableArray),
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).field),
-    enum: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                switch a {
-                | #FIRST => "FIRST"
-                | #SECOND => "SECOND"
-                | #THIRD => "THIRD"
-                }
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).enum),
-    embeddedInput: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) =>
-                        Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).embeddedInput),
-    custom: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).custom),
-  }
-  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = inp => {
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_EmbeddedInput).field),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = (
+    inp => {
+      nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
+      nullableArray: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).nullableArray),
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).field),
+      enum: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  switch a {
+                  | #FIRST => "FIRST"
+                  | #SECOND => "SECOND"
+                  | #THIRD => "THIRD"
+                  }
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).enum),
+      embeddedInput: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) =>
+                          Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).embeddedInput),
+      custom: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).custom),
+    }: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput
+  )
+  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = (
+    inp => {
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_EmbeddedInput).field),
+    }: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectNonrecursiveInput = (
     ~nonNullableField,

--- a/snapshot_tests/operations/expected/apollo/generate/customScalars.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/customScalars.res.txt
@@ -88,16 +88,18 @@ nonNullable
     }
     {customScalarField: customScalarField}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    opt: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).opt),
-    req: (a => a)((inp: t_variables).req),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      opt: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).opt),
+      req: (a => a)((inp: t_variables).req),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~opt=?, ~req, ()): t_variables => {opt, req}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/apollo/generate/customTypes.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/customTypes.res.txt
@@ -25,21 +25,25 @@ module NullableString = {
     | Red
     | Green
     | Blue
-  let parse: option<string> => t = color =>
-    switch color {
-    | Some("green") => Green
-    | Some("blue") => Blue
-    | Some("red") => Red
-    | Some(_)
-    | None =>
-      Red
-    }
-  let serialize: t => option<string> = color =>
-    switch color {
-    | Red => Some("red")
-    | Green => Some("green")
-    | Blue => Some("blue")
-    }
+  let parse: option<string> => t = (
+    color =>
+      switch color {
+      | Some("green") => Green
+      | Some("blue") => Blue
+      | Some("red") => Red
+      | Some(_)
+      | None =>
+        Red
+      }: option<string> => t
+  )
+  let serialize: t => option<string> = (
+    color =>
+      switch color {
+      | Red => Some("red")
+      | Green => Some("green")
+      | Blue => Some("blue")
+      }: t => option<string>
+  )
 }
 
 module DateTime = {

--- a/snapshot_tests/operations/expected/apollo/generate/enumInput.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/enumInput.res.txt
@@ -42,16 +42,18 @@ enumInput(arg: $arg)
     }
     {enumInput: enumInput}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (
-      a =>
-        switch a {
-        | #FIRST => "FIRST"
-        | #SECOND => "SECOND"
-        | #THIRD => "THIRD"
-        }
-    )((inp: t_variables).arg),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (
+        a =>
+          switch a {
+          | #FIRST => "FIRST"
+          | #SECOND => "SECOND"
+          | #THIRD => "THIRD"
+          }
+      )((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/apollo/generate/ewert_reproduction.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/ewert_reproduction.res.txt
@@ -49,60 +49,56 @@ lastname
 
 }
 "
-  let parse = (
-    (value): t => {
-      user: {
-        let value = (value: Raw.t).user
-        (
-          {
-            id: {
-              let value = (value: Raw.t_user).id
-              value
-            },
-            firstname: {
-              let value = (value: Raw.t_user).firstname
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            },
-            lastname: {
-              let value = (value: Raw.t_user).lastname
-              value
-            },
-          }: t_user
-        )
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let user = {
-        let value = (value: t).user
-        (
-          {
-            let lastname = {
-              let value = (value: t_user).lastname
-              value
+  let parse = (value): t => {
+    user: {
+      let value = (value: Raw.t).user
+      (
+        {
+          id: {
+            let value = (value: Raw.t_user).id
+            value
+          },
+          firstname: {
+            let value = (value: Raw.t_user).firstname
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
             }
-            and firstname = {
-              let value = (value: t_user).firstname
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
+          },
+          lastname: {
+            let value = (value: Raw.t_user).lastname
+            value
+          },
+        }: t_user
+      )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let user = {
+      let value = (value: t).user
+      (
+        {
+          let lastname = {
+            let value = (value: t_user).lastname
+            value
+          }
+          and firstname = {
+            let value = (value: t_user).firstname
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
             }
-            and id = {
-              let value = (value: t_user).id
-              value
-            }
-            {id, firstname, lastname}
-          }: Raw.t_user
-        )
-      }
-      {user: user}
-    }: t => Raw.t
-  )
+          }
+          and id = {
+            let value = (value: t_user).id
+            value
+          }
+          {id, firstname, lastname}
+        }: Raw.t_user
+      )
+    }
+    {user: user}
+  }
   let verifyArgsAndParse = (
     ~userId as _userId: [#NonNull_String],
     ~fragmentName as _UserData: [#UserData],

--- a/snapshot_tests/operations/expected/apollo/generate/fragmentDefinition.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/fragmentDefinition.res.txt
@@ -709,15 +709,17 @@ l5: lists  {
     }
     {l1, l2, l3, l4, l5}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg1: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).arg1),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg1: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).arg1),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~arg1=?, ()): t_variables => {arg1: arg1}
   let makeDefaultVariables = () => makeVariables()
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"

--- a/snapshot_tests/operations/expected/apollo/generate/fragmentDefinition.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/fragmentDefinition.res.txt
@@ -45,59 +45,55 @@ nullableOfNullable
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment: [#ListFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -136,29 +132,25 @@ function back to the original JSON-compatible data ")
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNonNullable: nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNonNullable: nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _Another: [#Another], value: Raw.t) => parse(value)
   let verifyName = x => switch x {
   | #Another => ()
@@ -196,45 +188,41 @@ function back to the original JSON-compatible data ")
 listWithArg(arg1: $arg1)  
 }
 "
-  let parse = (
-    (value): t => {
-      listWithArg: {
-        let value = (value: Raw.t).listWithArg
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let listWithArg = {
-        let value = (value: t).listWithArg
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    listWithArg: {
+      let value = (value: Raw.t).listWithArg
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      {listWithArg: listWithArg}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let listWithArg = {
+      let value = (value: t).listWithArg
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {listWithArg: listWithArg}
+  }
   let verifyArgsAndParse = (
     ~arg1 as _arg1: [#String],
     ~fragmentName as _FragmentWithArgs: [#FragmentWithArgs],
@@ -266,59 +254,55 @@ nullableOfNullable
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (
     ~fragmentName as _InlineListFragment: [#InlineListFragment],
     value: Raw.t,
@@ -349,59 +333,55 @@ nullableOfNullable
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (
     ~fragmentName as _InlineListFragment: [#InlineListFragment],
     value: Raw.t,

--- a/snapshot_tests/operations/expected/apollo/generate/fragmentInFragment.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/fragmentInFragment.res.txt
@@ -32,45 +32,41 @@ function back to the original JSON-compatible data ")
 nullableOfNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      {nullableOfNullable: nullableOfNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable: nullableOfNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment: [#ListFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -119,59 +115,55 @@ nullableOfNullable
 ",
     ListFragment.query,
   )
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "nullableOfNullable"))
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      listFragment: {
-        let value = (Obj.magic(value): ListFragment.Raw.t)
-
-        ListFragment.verifyArgsAndParse(~fragmentName=#ListFragment, value)
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t =>
-      Obj.magic(
-        Js.Array2.reduce(
-          [(Obj.magic(ListFragment.serialize((value: t).listFragment)): Js.Json.t)],
-          Graphql_ppx_runtime.deepMerge,
-          (
-            Obj.magic({
-              let nullableOfNullable = {
-                let value = (value: t).nullableOfNullable
-                switch value {
-                | Some(value) =>
-                  Js.Nullable.return(
-                    Js.Array2.map(value, value =>
-                      switch value {
-                      | Some(value) => Js.Nullable.return(value)
-                      | None => Js.Nullable.null
-                      }
-                    ),
-                  )
-                | None => Js.Nullable.null
-                }
-              }
-              {"nullableOfNullable": nullableOfNullable}
-            }): Js.Json.t
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "nullableOfNullable"))
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
           ),
+        )
+      | None => None
+      }
+    },
+    listFragment: {
+      let value = (Obj.magic(value): ListFragment.Raw.t)
+
+      ListFragment.verifyArgsAndParse(~fragmentName=#ListFragment, value)
+    },
+  }
+  let serialize = (value): Raw.t =>
+    Obj.magic(
+      Js.Array2.reduce(
+        [(Obj.magic(ListFragment.serialize((value: t).listFragment)): Js.Json.t)],
+        Graphql_ppx_runtime.deepMerge,
+        (
+          Obj.magic({
+            let nullableOfNullable = {
+              let value = (value: t).nullableOfNullable
+              switch value {
+              | Some(value) =>
+                Js.Nullable.return(
+                  Js.Array2.map(value, value =>
+                    switch value {
+                    | Some(value) => Js.Nullable.return(value)
+                    | None => Js.Nullable.null
+                    }
+                  ),
+                )
+              | None => Js.Nullable.null
+              }
+            }
+            {"nullableOfNullable": nullableOfNullable}
+          }): Js.Json.t
         ),
-      ): t => Raw.t
-  )
+      ),
+    )
   let verifyArgsAndParse = (~fragmentName as _Another: [#Another], value: Raw.t) => parse(value)
   let verifyName = x => switch x {
   | #Another => ()

--- a/snapshot_tests/operations/expected/apollo/generate/fragmentOnInterface.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/fragmentOnInterface.res.txt
@@ -45,23 +45,19 @@ __typename
 id  
 }
 "
-  let parse = (
-    (value): t => {
-      id: {
-        let value = (value: Raw.t).id
-        value
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let id = {
-        let value = (value: t).id
-        value
-      }
-      {id: id}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    id: {
+      let value = (value: Raw.t).id
+      value
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let id = {
+      let value = (value: t).id
+      value
+    }
+    {id: id}
+  }
   let verifyArgsAndParse = (
     ~fragmentName as _InterfaceFragment: [#InterfaceFragment],
     value: Raw.t,
@@ -119,37 +115,33 @@ id
 ",
     InterfaceFragment.query,
   )
-  let parse = (
-    (value): t => {
-      id: {
-        let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "id"))
-        value
-      },
-      interfaceFragment: {
-        let value = (Obj.magic(value): InterfaceFragment.Raw.t)
+  let parse = (value): t => {
+    id: {
+      let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "id"))
+      value
+    },
+    interfaceFragment: {
+      let value = (Obj.magic(value): InterfaceFragment.Raw.t)
 
-        InterfaceFragment.verifyArgsAndParse(~fragmentName=#InterfaceFragment, value)
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t =>
-      Obj.magic(
-        Js.Array2.reduce(
-          [(Obj.magic(InterfaceFragment.serialize((value: t).interfaceFragment)): Js.Json.t)],
-          Graphql_ppx_runtime.deepMerge,
-          (
-            Obj.magic({
-              let id = {
-                let value = (value: t).id
-                value
-              }
-              {"id": id}
-            }): Js.Json.t
-          ),
+      InterfaceFragment.verifyArgsAndParse(~fragmentName=#InterfaceFragment, value)
+    },
+  }
+  let serialize = (value): Raw.t =>
+    Obj.magic(
+      Js.Array2.reduce(
+        [(Obj.magic(InterfaceFragment.serialize((value: t).interfaceFragment)): Js.Json.t)],
+        Graphql_ppx_runtime.deepMerge,
+        (
+          Obj.magic({
+            let id = {
+              let value = (value: t).id
+              value
+            }
+            {"id": id}
+          }): Js.Json.t
         ),
-      ): t => Raw.t
-  )
+      ),
+    )
   let verifyArgsAndParse = (~fragmentName as _AnotherFragment: [#AnotherFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -192,37 +184,33 @@ id
 ",
     InterfaceFragment.query,
   )
-  let parse = (
-    (value): t => {
-      id: {
-        let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "id"))
-        value
-      },
-      interfaceFragment: {
-        let value = (Obj.magic(value): InterfaceFragment.Raw.t)
+  let parse = (value): t => {
+    id: {
+      let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "id"))
+      value
+    },
+    interfaceFragment: {
+      let value = (Obj.magic(value): InterfaceFragment.Raw.t)
 
-        InterfaceFragment.verifyArgsAndParse(~fragmentName=#InterfaceFragment, value)
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t =>
-      Obj.magic(
-        Js.Array2.reduce(
-          [(Obj.magic(InterfaceFragment.serialize((value: t).interfaceFragment)): Js.Json.t)],
-          Graphql_ppx_runtime.deepMerge,
-          (
-            Obj.magic({
-              let id = {
-                let value = (value: t).id
-                value
-              }
-              {"id": id}
-            }): Js.Json.t
-          ),
+      InterfaceFragment.verifyArgsAndParse(~fragmentName=#InterfaceFragment, value)
+    },
+  }
+  let serialize = (value): Raw.t =>
+    Obj.magic(
+      Js.Array2.reduce(
+        [(Obj.magic(InterfaceFragment.serialize((value: t).interfaceFragment)): Js.Json.t)],
+        Graphql_ppx_runtime.deepMerge,
+        (
+          Obj.magic({
+            let id = {
+              let value = (value: t).id
+              value
+            }
+            {"id": id}
+          }): Js.Json.t
         ),
-      ): t => Raw.t
-  )
+      ),
+    )
   let verifyArgsAndParse = (~fragmentName as _AnonUser: [#AnonUser], value: Raw.t) => parse(value)
   let verifyName = x => switch x {
   | #AnonUser => ()

--- a/snapshot_tests/operations/expected/apollo/generate/fragmentUnion.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/fragmentUnion.res.txt
@@ -37,23 +37,19 @@ function back to the original JSON-compatible data ")
 name  
 }
 "
-  let parse = (
-    (value): t => {
-      name: {
-        let value = (value: Raw.t).name
-        value
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let name = {
-        let value = (value: t).name
-        value
-      }
-      {name: name}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    name: {
+      let value = (value: Raw.t).name
+      value
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let name = {
+      let value = (value: t).name
+      value
+    }
+    {name: name}
+  }
   let verifyArgsAndParse = (~fragmentName as _DogFragment: [#DogFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -92,23 +88,19 @@ function back to the original JSON-compatible data ")
 name  
 }
 "
-  let parse = (
-    (value): t => {
-      name: {
-        let value = (value: Raw.t).name
-        value
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let name = {
-        let value = (value: t).name
-        value
-      }
-      {name: name}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    name: {
+      let value = (value: Raw.t).name
+      value
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let name = {
+      let value = (value: t).name
+      value
+    }
+    {name: name}
+  }
   let verifyArgsAndParse = (~fragmentName as _HumanFragment: [#HumanFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/apollo/generate/fragmentUnion.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/fragmentUnion.res.txt
@@ -1,9 +1,11 @@
 module Graphql_ppx_runtime = {
   // mock
-  let assign_typename: (
-    Js.Json.t,
-    string,
-  ) => Js.Json.t = %raw(` (obj, typename) => { obj.__typename = typename; return obj } `)
+  let assign_typename: (Js.Json.t, string) => Js.Json.t = (
+    %raw(` (obj, typename) => { obj.__typename = typename; return obj } `): (
+      Js.Json.t,
+      string,
+    ) => Js.Json.t
+  )
 }
 module DogFragment: {
   @@ocaml.warning("-32-30")

--- a/snapshot_tests/operations/expected/apollo/generate/fragmentWithdifferentReturnType.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/fragmentWithdifferentReturnType.res.txt
@@ -41,59 +41,55 @@ nullableOfNullable
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment: [#ListFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/apollo/generate/fragmentvariableinput.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/fragmentvariableinput.res.txt
@@ -35,54 +35,50 @@ id
 
 }
 "
-  let parse = (
-    (value): t => {
-      reposts: {
-        let value = (value: Raw.t).reposts
-        Js.Array2.map(value, value =>
-          switch Js.toOption(value) {
-          | Some(value) =>
-            Some(
-              (
-                {
-                  id: {
-                    let value = (value: Raw.t_reposts).id
-                    value
-                  },
-                }: t_reposts
-              ),
-            )
-          | None => None
-          }
-        )
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let reposts = {
-        let value = (value: t).reposts
-        Js.Array2.map(value, value =>
-          switch value {
-          | Some(value) =>
-            Js.Nullable.return(
-              (
-                {
-                  let id = {
-                    let value = (value: t_reposts).id
-                    value
-                  }
-                  {id: id}
-                }: Raw.t_reposts
-              ),
-            )
-          | None => Js.Nullable.null
-          }
-        )
-      }
-      {reposts: reposts}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    reposts: {
+      let value = (value: Raw.t).reposts
+      Js.Array2.map(value, value =>
+        switch Js.toOption(value) {
+        | Some(value) =>
+          Some(
+            (
+              {
+                id: {
+                  let value = (value: Raw.t_reposts).id
+                  value
+                },
+              }: t_reposts
+            ),
+          )
+        | None => None
+        }
+      )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let reposts = {
+      let value = (value: t).reposts
+      Js.Array2.map(value, value =>
+        switch value {
+        | Some(value) =>
+          Js.Nullable.return(
+            (
+              {
+                let id = {
+                  let value = (value: t_reposts).id
+                  value
+                }
+                {id: id}
+              }: Raw.t_reposts
+            ),
+          )
+        | None => Js.Nullable.null
+        }
+      )
+    }
+    {reposts: reposts}
+  }
   let verifyArgsAndParse = (
     ~name as _name: [#NonNull_String],
     ~fragmentName as _test: [#test],

--- a/snapshot_tests/operations/expected/apollo/generate/hasuraRepro.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/hasuraRepro.res.txt
@@ -28,23 +28,19 @@ function back to the original JSON-compatible data ")
 name  
 }
 "
-  let parse = (
-    (value): t => {
-      name: {
-        let value = (value: Raw.t).name
-        value
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let name = {
-        let value = (value: t).name
-        value
-      }
-      {name: name}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    name: {
+      let value = (value: Raw.t).name
+      value
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let name = {
+      let value = (value: t).name
+      value
+    }
+    {name: name}
+  }
   let verifyArgsAndParse = (~fragmentName as _Dog: [#Dog], value: Raw.t) => parse(value)
   let verifyName = x => switch x {
   | #Dog => ()

--- a/snapshot_tests/operations/expected/apollo/generate/hasuraRepro.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/hasuraRepro.res.txt
@@ -118,22 +118,24 @@ hasuraRepro(orderBy: [{id: desc}], block: {number: $blockNumber, type: $type})  
     }
     {hasuraRepro: hasuraRepro}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    blockNumber: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).blockNumber),
-    type_: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).type_),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      blockNumber: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).blockNumber),
+      type_: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).type_),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~blockNumber=?, ~type_=?, ()): t_variables => {blockNumber, type_}
   let makeDefaultVariables = () => makeVariables()
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"

--- a/snapshot_tests/operations/expected/apollo/generate/listsArgs.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/listsArgs.res.txt
@@ -68,51 +68,53 @@ listsInput(arg: {nullableOfNullable: $nullableOfNullable, nullableOfNonNullable:
     }
     {listsInput: listsInput}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    nullableOfNullable: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      nullableOfNullable: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables).nullableOfNullable),
+      nullableOfNonNullable: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => Js.Array2.map(a, b => (a => a)(b)))(b))
+          }
+      )((inp: t_variables).nullableOfNonNullable),
+      nonNullableOfNullable: (
+        a =>
+          Js.Array2.map(a, b =>
             (
               a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
+                switch a {
+                | None => Js.Nullable.undefined
+                | Some(b) => Js.Nullable.return((a => a)(b))
+                }
+            )(b)
           )
-        }
-    )((inp: t_variables).nullableOfNullable),
-    nullableOfNonNullable: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => Js.Array2.map(a, b => (a => a)(b)))(b))
-        }
-    )((inp: t_variables).nullableOfNonNullable),
-    nonNullableOfNullable: (
-      a =>
-        Js.Array2.map(a, b =>
-          (
-            a =>
-              switch a {
-              | None => Js.Nullable.undefined
-              | Some(b) => Js.Nullable.return((a => a)(b))
-              }
-          )(b)
-        )
-    )((inp: t_variables).nonNullableOfNullable),
-    nonNullableOfNonNullable: (a => Js.Array2.map(a, b => (a => a)(b)))(
-      (inp: t_variables).nonNullableOfNonNullable,
-    ),
-  }
+      )((inp: t_variables).nonNullableOfNullable),
+      nonNullableOfNonNullable: (a => Js.Array2.map(a, b => (a => a)(b)))(
+        (inp: t_variables).nonNullableOfNonNullable,
+      ),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (
     ~nullableOfNullable=?,
     ~nullableOfNonNullable=?,

--- a/snapshot_tests/operations/expected/apollo/generate/listsInput.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/listsInput.res.txt
@@ -74,54 +74,58 @@ listsInput(arg: $arg)
     }
     {listsInput: listsInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectListsInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectListsInput: t_variables_ListsInput => Raw.t_variables_ListsInput = inp => {
-    nullableOfNullable: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectListsInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectListsInput: t_variables_ListsInput => Raw.t_variables_ListsInput = (
+    inp => {
+      nullableOfNullable: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_ListsInput).nullableOfNullable),
+      nullableOfNonNullable: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => Js.Array2.map(a, b => (a => a)(b)))(b))
+          }
+      )((inp: t_variables_ListsInput).nullableOfNonNullable),
+      nonNullableOfNullable: (
+        a =>
+          Js.Array2.map(a, b =>
             (
               a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
+                switch a {
+                | None => Js.Nullable.undefined
+                | Some(b) => Js.Nullable.return((a => a)(b))
+                }
+            )(b)
           )
-        }
-    )((inp: t_variables_ListsInput).nullableOfNullable),
-    nullableOfNonNullable: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => Js.Array2.map(a, b => (a => a)(b)))(b))
-        }
-    )((inp: t_variables_ListsInput).nullableOfNonNullable),
-    nonNullableOfNullable: (
-      a =>
-        Js.Array2.map(a, b =>
-          (
-            a =>
-              switch a {
-              | None => Js.Nullable.undefined
-              | Some(b) => Js.Nullable.return((a => a)(b))
-              }
-          )(b)
-        )
-    )((inp: t_variables_ListsInput).nonNullableOfNullable),
-    nonNullableOfNonNullable: (a => Js.Array2.map(a, b => (a => a)(b)))(
-      (inp: t_variables_ListsInput).nonNullableOfNonNullable,
-    ),
-  }
+      )((inp: t_variables_ListsInput).nonNullableOfNullable),
+      nonNullableOfNonNullable: (a => Js.Array2.map(a, b => (a => a)(b)))(
+        (inp: t_variables_ListsInput).nonNullableOfNonNullable,
+      ),
+    }: t_variables_ListsInput => Raw.t_variables_ListsInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectListsInput = (
     ~nullableOfNullable=?,

--- a/snapshot_tests/operations/expected/apollo/generate/module_type.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/module_type.res.txt
@@ -263,8 +263,10 @@ and VariousScalars: {
   let parse = (nestedObject: MyQueryRecursive.t_nestedObject) => {
     otherInner: nestedObject.inner,
   }
-  let serialize: t => MyQueryRecursive.t_nestedObject = t => {
-    inner: t.otherInner,
-  }
+  let serialize: t => MyQueryRecursive.t_nestedObject = (
+    t => {
+      inner: t.otherInner,
+    }: t => MyQueryRecursive.t_nestedObject
+  )
 }
 

--- a/snapshot_tests/operations/expected/apollo/generate/mutationWithArgs.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/mutationWithArgs.res.txt
@@ -42,9 +42,9 @@ optionalInputArgs(required: $required, anotherRequired: "val")
     }
     {optionalInputArgs: optionalInputArgs}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    required: (a => a)((inp: t_variables).required),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {required: (a => a)((inp: t_variables).required)}: t_variables => Raw.t_variables
+  )
   let makeVariables = (~required, ()): t_variables => {required: required}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/apollo/generate/mutationWithArgsAndNoRecords.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/mutationWithArgsAndNoRecords.res.txt
@@ -42,9 +42,9 @@ optionalInputArgs(required: $required, anotherRequired: "val")
     }
     {optionalInputArgs: optionalInputArgs}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    required: (a => a)((inp: t_variables).required),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {required: (a => a)((inp: t_variables).required)}: t_variables => Raw.t_variables
+  )
   let makeVariables = (~required, ()): t_variables => {required: required}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/apollo/generate/nonrecursiveInput.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/nonrecursiveInput.res.txt
@@ -90,95 +90,101 @@ nonrecursiveInput(arg: $arg)
     }
     {nonrecursiveInput: nonrecursiveInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = inp => {
-    nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
-    nullableArray: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).nullableArray),
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).field),
-    enum: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                switch a {
-                | #FIRST => "FIRST"
-                | #SECOND => "SECOND"
-                | #THIRD => "THIRD"
-                }
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).enum),
-    embeddedInput: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) =>
-                        Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).embeddedInput),
-    custom: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).custom),
-  }
-  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = inp => {
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_EmbeddedInput).field),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = (
+    inp => {
+      nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
+      nullableArray: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).nullableArray),
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).field),
+      enum: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  switch a {
+                  | #FIRST => "FIRST"
+                  | #SECOND => "SECOND"
+                  | #THIRD => "THIRD"
+                  }
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).enum),
+      embeddedInput: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) =>
+                          Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).embeddedInput),
+      custom: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).custom),
+    }: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput
+  )
+  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = (
+    inp => {
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_EmbeddedInput).field),
+    }: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectNonrecursiveInput = (
     ~nonNullableField,
@@ -315,96 +321,102 @@ more: scalarsInput(arg: $arg2)
     }
     {scalarsInput, more}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
-    arg2: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg2),
-  }
-  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = inp => {
-    nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
-    nullableArray: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).nullableArray),
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).field),
-    enum: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                switch a {
-                | #FIRST => "FIRST"
-                | #SECOND => "SECOND"
-                | #THIRD => "THIRD"
-                }
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).enum),
-    embeddedInput: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) =>
-                        Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).embeddedInput),
-    custom: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).custom),
-  }
-  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = inp => {
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_EmbeddedInput).field),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
+      arg2: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg2),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = (
+    inp => {
+      nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
+      nullableArray: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).nullableArray),
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).field),
+      enum: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  switch a {
+                  | #FIRST => "FIRST"
+                  | #SECOND => "SECOND"
+                  | #THIRD => "THIRD"
+                  }
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).enum),
+      embeddedInput: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) =>
+                          Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).embeddedInput),
+      custom: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).custom),
+    }: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput
+  )
+  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = (
+    inp => {
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_EmbeddedInput).field),
+    }: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput
+  )
   let makeVariables = (~arg, ~arg2, ()): t_variables => {arg, arg2}
   and makeInputObjectNonrecursiveInput = (
     ~nonNullableField,

--- a/snapshot_tests/operations/expected/apollo/generate/pokedexScalars.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/pokedexScalars.res.txt
@@ -101,22 +101,24 @@ name
     }
     {pokemon: pokemon}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    id: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).id),
-    name: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).name),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      id: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).id),
+      name: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).name),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~id=?, ~name=?, ()): t_variables => {id, name}
   let makeDefaultVariables = () => makeVariables()
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
@@ -226,22 +228,24 @@ name
     }
     {pokemon: pokemon}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    id: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).id),
-    name: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).name),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      id: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).id),
+      name: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).name),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~id=?, ~name=?, ()): t_variables => {id, name}
   let makeDefaultVariables = () => makeVariables()
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"

--- a/snapshot_tests/operations/expected/apollo/generate/record.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/record.res.txt
@@ -333,31 +333,27 @@ string
 int  
 }
 "
-    let parse = (
-      (value): t => {
-        string: {
-          let value = (value: Raw.t).string
-          value
-        },
-        int: {
-          let value = (value: Raw.t).int
-          value
-        },
-      }: Raw.t => t
-    )
-    let serialize = (
-      (value): Raw.t => {
-        let int = {
-          let value = (value: t).int
-          value
-        }
-        and string = {
-          let value = (value: t).string
-          value
-        }
-        {string, int}
-      }: t => Raw.t
-    )
+    let parse = (value): t => {
+      string: {
+        let value = (value: Raw.t).string
+        value
+      },
+      int: {
+        let value = (value: Raw.t).int
+        value
+      },
+    }
+    let serialize = (value): Raw.t => {
+      let int = {
+        let value = (value: t).int
+        value
+      }
+      and string = {
+        let value = (value: t).string
+        value
+      }
+      {string, int}
+    }
     let verifyArgsAndParse = (~fragmentName as _Fragment: [#Fragment], value: Raw.t) => parse(value)
     let verifyName = x => switch x {
     | #Fragment => ()
@@ -600,39 +596,35 @@ name
 barkVolume  
 }
 "
-    let parse = (
-      (value): t => {
-        __typename: {
-          let value = (value: Raw.t).__typename
-          value
-        },
-        name: {
-          let value = (value: Raw.t).name
-          value
-        },
-        barkVolume: {
-          let value = (value: Raw.t).barkVolume
-          value
-        },
-      }: Raw.t => t
-    )
-    let serialize = (
-      (value): Raw.t => {
-        let barkVolume = {
-          let value = (value: t).barkVolume
-          value
-        }
-        and name = {
-          let value = (value: t).name
-          value
-        }
-        and __typename = {
-          let value = (value: t).__typename
-          value
-        }
-        {__typename, name, barkVolume}
-      }: t => Raw.t
-    )
+    let parse = (value): t => {
+      __typename: {
+        let value = (value: Raw.t).__typename
+        value
+      },
+      name: {
+        let value = (value: Raw.t).name
+        value
+      },
+      barkVolume: {
+        let value = (value: Raw.t).barkVolume
+        value
+      },
+    }
+    let serialize = (value): Raw.t => {
+      let barkVolume = {
+        let value = (value: t).barkVolume
+        value
+      }
+      and name = {
+        let value = (value: t).name
+        value
+      }
+      and __typename = {
+        let value = (value: t).__typename
+        value
+      }
+      {__typename, name, barkVolume}
+    }
     let verifyArgsAndParse = (~fragmentName as _DogFragment: [#DogFragment], value: Raw.t) =>
       parse(value)
     let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/apollo/generate/recursiveInput.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/recursiveInput.res.txt
@@ -69,42 +69,46 @@ recursiveInput(arg: $arg)
     }
     {recursiveInput: recursiveInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectRecursiveInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectRecursiveInput: t_variables_RecursiveInput => Raw.t_variables_RecursiveInput = inp => {
-    otherField: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_RecursiveInput).otherField),
-    inner: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => serializeInputObjectRecursiveInput(a))(b))
-        }
-    )((inp: t_variables_RecursiveInput).inner),
-    enum: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                switch a {
-                | #FIRST => "FIRST"
-                | #SECOND => "SECOND"
-                | #THIRD => "THIRD"
-                }
-            )(b),
-          )
-        }
-    )((inp: t_variables_RecursiveInput).enum),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectRecursiveInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectRecursiveInput: t_variables_RecursiveInput => Raw.t_variables_RecursiveInput = (
+    inp => {
+      otherField: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_RecursiveInput).otherField),
+      inner: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => serializeInputObjectRecursiveInput(a))(b))
+          }
+      )((inp: t_variables_RecursiveInput).inner),
+      enum: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  switch a {
+                  | #FIRST => "FIRST"
+                  | #SECOND => "SECOND"
+                  | #THIRD => "THIRD"
+                  }
+              )(b),
+            )
+          }
+      )((inp: t_variables_RecursiveInput).enum),
+    }: t_variables_RecursiveInput => Raw.t_variables_RecursiveInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectRecursiveInput = (
     ~otherField=?,
@@ -200,37 +204,45 @@ recursiveRepro(input: $input)
     }
     {recursiveRepro: recursiveRepro}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    input: (a => serializeInputObjectproblem_input(a))((inp: t_variables).input),
-  }
-  and serializeInputObjectproblem_input: t_variables_problem_input => Raw.t_variables_problem_input = inp => {
-    the_problem: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => serializeInputObjectthis_will_be_duplicated(a))(b))
-        }
-    )((inp: t_variables_problem_input).the_problem),
-    b: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => serializeInputObjectnested_type(a))(b))
-        }
-    )((inp: t_variables_problem_input).b),
-  }
-  and serializeInputObjectthis_will_be_duplicated: t_variables_this_will_be_duplicated => Raw.t_variables_this_will_be_duplicated = inp => {
-    id: (a => a)((inp: t_variables_this_will_be_duplicated).id),
-  }
-  and serializeInputObjectnested_type: t_variables_nested_type => Raw.t_variables_nested_type = inp => {
-    the_problem: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => serializeInputObjectthis_will_be_duplicated(a))(b))
-        }
-    )((inp: t_variables_nested_type).the_problem),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      input: (a => serializeInputObjectproblem_input(a))((inp: t_variables).input),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectproblem_input: t_variables_problem_input => Raw.t_variables_problem_input = (
+    inp => {
+      the_problem: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => serializeInputObjectthis_will_be_duplicated(a))(b))
+          }
+      )((inp: t_variables_problem_input).the_problem),
+      b: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => serializeInputObjectnested_type(a))(b))
+          }
+      )((inp: t_variables_problem_input).b),
+    }: t_variables_problem_input => Raw.t_variables_problem_input
+  )
+  and serializeInputObjectthis_will_be_duplicated: t_variables_this_will_be_duplicated => Raw.t_variables_this_will_be_duplicated = (
+    inp => {
+      id: (a => a)((inp: t_variables_this_will_be_duplicated).id),
+    }: t_variables_this_will_be_duplicated => Raw.t_variables_this_will_be_duplicated
+  )
+  and serializeInputObjectnested_type: t_variables_nested_type => Raw.t_variables_nested_type = (
+    inp => {
+      the_problem: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => serializeInputObjectthis_will_be_duplicated(a))(b))
+          }
+      )((inp: t_variables_nested_type).the_problem),
+    }: t_variables_nested_type => Raw.t_variables_nested_type
+  )
   let makeVariables = (~input, ()): t_variables => {input: input}
   and makeInputObjectproblem_input = (~the_problem=?, ~b=?, ()): t_variables_problem_input => {
     the_problem,

--- a/snapshot_tests/operations/expected/apollo/generate/scalarsArgs.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/scalarsArgs.res.txt
@@ -98,48 +98,50 @@ scalarsInput(arg: {nullableString: $nullableString, string: $string, nullableInt
     }
     {scalarsInput: scalarsInput}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    nullableString: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableString),
-    string: (a => a)((inp: t_variables).string),
-    nullableInt: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableInt),
-    int: (a => a)((inp: t_variables).int),
-    nullableFloat: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableFloat),
-    float: (a => a)((inp: t_variables).float),
-    nullableBoolean: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableBoolean),
-    boolean: (a => a)((inp: t_variables).boolean),
-    nullableID: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableID),
-    id: (a => a)((inp: t_variables).id),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      nullableString: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableString),
+      string: (a => a)((inp: t_variables).string),
+      nullableInt: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableInt),
+      int: (a => a)((inp: t_variables).int),
+      nullableFloat: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableFloat),
+      float: (a => a)((inp: t_variables).float),
+      nullableBoolean: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableBoolean),
+      boolean: (a => a)((inp: t_variables).boolean),
+      nullableID: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableID),
+      id: (a => a)((inp: t_variables).id),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (
     ~nullableString=?,
     ~string,

--- a/snapshot_tests/operations/expected/apollo/generate/scalarsInput.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/scalarsInput.res.txt
@@ -104,51 +104,55 @@ scalarsInput(arg: $arg)
     }
     {scalarsInput: scalarsInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectVariousScalarsInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectVariousScalarsInput: t_variables_VariousScalarsInput => Raw.t_variables_VariousScalarsInput = inp => {
-    nullableString: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableString),
-    string: (a => a)((inp: t_variables_VariousScalarsInput).string),
-    nullableInt: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableInt),
-    int: (a => a)((inp: t_variables_VariousScalarsInput).int),
-    nullableFloat: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableFloat),
-    float: (a => a)((inp: t_variables_VariousScalarsInput).float),
-    nullableBoolean: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableBoolean),
-    boolean: (a => a)((inp: t_variables_VariousScalarsInput).boolean),
-    nullableID: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableID),
-    id: (a => a)((inp: t_variables_VariousScalarsInput).id),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectVariousScalarsInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectVariousScalarsInput: t_variables_VariousScalarsInput => Raw.t_variables_VariousScalarsInput = (
+    inp => {
+      nullableString: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableString),
+      string: (a => a)((inp: t_variables_VariousScalarsInput).string),
+      nullableInt: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableInt),
+      int: (a => a)((inp: t_variables_VariousScalarsInput).int),
+      nullableFloat: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableFloat),
+      float: (a => a)((inp: t_variables_VariousScalarsInput).float),
+      nullableBoolean: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableBoolean),
+      boolean: (a => a)((inp: t_variables_VariousScalarsInput).boolean),
+      nullableID: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableID),
+      id: (a => a)((inp: t_variables_VariousScalarsInput).id),
+    }: t_variables_VariousScalarsInput => Raw.t_variables_VariousScalarsInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectVariousScalarsInput = (
     ~nullableString=?,

--- a/snapshot_tests/operations/expected/apollo/generate/skipDirectives.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/skipDirectives.res.txt
@@ -164,9 +164,9 @@ string @include(if: $var)
     }
     {v1, v2}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    var: (a => a)((inp: t_variables).var),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {var: (a => a)((inp: t_variables).var)}: t_variables => Raw.t_variables
+  )
   let makeVariables = (~var, ()): t_variables => {var: var}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/apollo/generate/tagged_template.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/tagged_template.res.txt
@@ -1545,59 +1545,55 @@ nullableOfNonNullable
     ],
     [],
   )
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment: [#ListFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -1847,59 +1843,55 @@ nullableOfNonNullable
     ],
     [],
   )
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment8: [#ListFragment8], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/apollo/generate/union.res.txt
+++ b/snapshot_tests/operations/expected/apollo/generate/union.res.txt
@@ -541,31 +541,27 @@ name
 __typename  
 }
 "
-    let parse = (
-      (value): named => {
-        name: {
-          let value = (value: Raw.t).name
-          value
-        },
-        __typename: {
-          let value = (value: Raw.t).__typename
-          value
-        },
-      }: Raw.t => named
-    )
-    let serialize = (
-      (value): Raw.t => {
-        let __typename = {
-          let value = (value: named).__typename
-          value
-        }
-        and name = {
-          let value = (value: named).name
-          value
-        }
-        {name, __typename}
-      }: named => Raw.t
-    )
+    let parse = (value): named => {
+      name: {
+        let value = (value: Raw.t).name
+        value
+      },
+      __typename: {
+        let value = (value: Raw.t).__typename
+        value
+      },
+    }
+    let serialize = (value): Raw.t => {
+      let __typename = {
+        let value = (value: named).__typename
+        value
+      }
+      and name = {
+        let value = (value: named).name
+        value
+      }
+      {name, __typename}
+    }
     let verifyArgsAndParse = (~fragmentName as _DogFields: [#DogFields], value: Raw.t) =>
       parse(value)
     let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/native/generate/argNamedQuery.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/argNamedQuery.res.txt
@@ -42,9 +42,9 @@ argNamedQuery(query: $query)
     }
     {argNamedQuery: argNamedQuery}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    query: (a => a)((inp: t_variables).query),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {query: (a => a)((inp: t_variables).query)}: t_variables => Raw.t_variables
+  )
   let makeVariables = (~query, ()): t_variables => {query: query}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"
@@ -95,9 +95,9 @@ argNamedQuery(query: $query)
       }
       {argNamedQuery: argNamedQuery}
     }
-    let serializeVariables: t_variables => Raw.t_variables = inp => {
-      query: (a => a)((inp: t_variables).query),
-    }
+    let serializeVariables: t_variables => Raw.t_variables = (
+      inp => {query: (a => a)((inp: t_variables).query)}: t_variables => Raw.t_variables
+    )
     let makeVariables = (~query, ()): t_variables => {query: query}
     external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
     external toJson: Raw.t => Js.Json.t = "%identity"
@@ -147,9 +147,9 @@ argNamedQuery(query: $query)
       }
       {argNamedQuery: argNamedQuery}
     }
-    let serializeVariables: t_variables => Raw.t_variables = inp => {
-      query: (a => a)((inp: t_variables).query),
-    }
+    let serializeVariables: t_variables => Raw.t_variables = (
+      inp => {query: (a => a)((inp: t_variables).query)}: t_variables => Raw.t_variables
+    )
     let makeVariables = (~query, ()): t_variables => {query: query}
     external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
     external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/native/generate/comment.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/comment.res.txt
@@ -90,95 +90,101 @@ nonrecursiveInput(arg: $arg)
     }
     {nonrecursiveInput: nonrecursiveInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = inp => {
-    nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
-    nullableArray: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).nullableArray),
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).field),
-    enum: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                switch a {
-                | #FIRST => "FIRST"
-                | #SECOND => "SECOND"
-                | #THIRD => "THIRD"
-                }
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).enum),
-    embeddedInput: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) =>
-                        Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).embeddedInput),
-    custom: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).custom),
-  }
-  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = inp => {
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_EmbeddedInput).field),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = (
+    inp => {
+      nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
+      nullableArray: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).nullableArray),
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).field),
+      enum: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  switch a {
+                  | #FIRST => "FIRST"
+                  | #SECOND => "SECOND"
+                  | #THIRD => "THIRD"
+                  }
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).enum),
+      embeddedInput: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) =>
+                          Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).embeddedInput),
+      custom: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).custom),
+    }: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput
+  )
+  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = (
+    inp => {
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_EmbeddedInput).field),
+    }: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectNonrecursiveInput = (
     ~nonNullableField,

--- a/snapshot_tests/operations/expected/native/generate/customScalars.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/customScalars.res.txt
@@ -88,16 +88,18 @@ nonNullable
     }
     {customScalarField: customScalarField}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    opt: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).opt),
-    req: (a => a)((inp: t_variables).req),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      opt: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).opt),
+      req: (a => a)((inp: t_variables).req),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~opt=?, ~req, ()): t_variables => {opt, req}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/native/generate/customTypes.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/customTypes.res.txt
@@ -25,21 +25,25 @@ module NullableString = {
     | Red
     | Green
     | Blue
-  let parse: option<string> => t = color =>
-    switch color {
-    | Some("green") => Green
-    | Some("blue") => Blue
-    | Some("red") => Red
-    | Some(_)
-    | None =>
-      Red
-    }
-  let serialize: t => option<string> = color =>
-    switch color {
-    | Red => Some("red")
-    | Green => Some("green")
-    | Blue => Some("blue")
-    }
+  let parse: option<string> => t = (
+    color =>
+      switch color {
+      | Some("green") => Green
+      | Some("blue") => Blue
+      | Some("red") => Red
+      | Some(_)
+      | None =>
+        Red
+      }: option<string> => t
+  )
+  let serialize: t => option<string> = (
+    color =>
+      switch color {
+      | Red => Some("red")
+      | Green => Some("green")
+      | Blue => Some("blue")
+      }: t => option<string>
+  )
 }
 
 module DateTime = {

--- a/snapshot_tests/operations/expected/native/generate/enumInput.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/enumInput.res.txt
@@ -42,16 +42,18 @@ enumInput(arg: $arg)
     }
     {enumInput: enumInput}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (
-      a =>
-        switch a {
-        | #FIRST => "FIRST"
-        | #SECOND => "SECOND"
-        | #THIRD => "THIRD"
-        }
-    )((inp: t_variables).arg),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (
+        a =>
+          switch a {
+          | #FIRST => "FIRST"
+          | #SECOND => "SECOND"
+          | #THIRD => "THIRD"
+          }
+      )((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/native/generate/ewert_reproduction.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/ewert_reproduction.res.txt
@@ -49,60 +49,56 @@ lastname
 
 }
 "
-  let parse = (
-    (value): t => {
-      user: {
-        let value = (value: Raw.t).user
-        (
-          {
-            id: {
-              let value = (value: Raw.t_user).id
-              value
-            },
-            firstname: {
-              let value = (value: Raw.t_user).firstname
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            },
-            lastname: {
-              let value = (value: Raw.t_user).lastname
-              value
-            },
-          }: t_user
-        )
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let user = {
-        let value = (value: t).user
-        (
-          {
-            let lastname = {
-              let value = (value: t_user).lastname
-              value
+  let parse = (value): t => {
+    user: {
+      let value = (value: Raw.t).user
+      (
+        {
+          id: {
+            let value = (value: Raw.t_user).id
+            value
+          },
+          firstname: {
+            let value = (value: Raw.t_user).firstname
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
             }
-            and firstname = {
-              let value = (value: t_user).firstname
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
+          },
+          lastname: {
+            let value = (value: Raw.t_user).lastname
+            value
+          },
+        }: t_user
+      )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let user = {
+      let value = (value: t).user
+      (
+        {
+          let lastname = {
+            let value = (value: t_user).lastname
+            value
+          }
+          and firstname = {
+            let value = (value: t_user).firstname
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
             }
-            and id = {
-              let value = (value: t_user).id
-              value
-            }
-            {id, firstname, lastname}
-          }: Raw.t_user
-        )
-      }
-      {user: user}
-    }: t => Raw.t
-  )
+          }
+          and id = {
+            let value = (value: t_user).id
+            value
+          }
+          {id, firstname, lastname}
+        }: Raw.t_user
+      )
+    }
+    {user: user}
+  }
   let verifyArgsAndParse = (
     ~userId as _userId: [#NonNull_String],
     ~fragmentName as _UserData: [#UserData],

--- a/snapshot_tests/operations/expected/native/generate/fragmentDefinition.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/fragmentDefinition.res.txt
@@ -709,15 +709,17 @@ l5: lists  {
     }
     {l1, l2, l3, l4, l5}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg1: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).arg1),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg1: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).arg1),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~arg1=?, ()): t_variables => {arg1: arg1}
   let makeDefaultVariables = () => makeVariables()
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"

--- a/snapshot_tests/operations/expected/native/generate/fragmentDefinition.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/fragmentDefinition.res.txt
@@ -45,59 +45,55 @@ nullableOfNullable
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment: [#ListFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -136,29 +132,25 @@ function back to the original JSON-compatible data ")
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNonNullable: nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNonNullable: nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _Another: [#Another], value: Raw.t) => parse(value)
   let verifyName = x => switch x {
   | #Another => ()
@@ -196,45 +188,41 @@ function back to the original JSON-compatible data ")
 listWithArg(arg1: $arg1)  
 }
 "
-  let parse = (
-    (value): t => {
-      listWithArg: {
-        let value = (value: Raw.t).listWithArg
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let listWithArg = {
-        let value = (value: t).listWithArg
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    listWithArg: {
+      let value = (value: Raw.t).listWithArg
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      {listWithArg: listWithArg}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let listWithArg = {
+      let value = (value: t).listWithArg
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {listWithArg: listWithArg}
+  }
   let verifyArgsAndParse = (
     ~arg1 as _arg1: [#String],
     ~fragmentName as _FragmentWithArgs: [#FragmentWithArgs],
@@ -266,59 +254,55 @@ nullableOfNullable
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (
     ~fragmentName as _InlineListFragment: [#InlineListFragment],
     value: Raw.t,
@@ -349,59 +333,55 @@ nullableOfNullable
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (
     ~fragmentName as _InlineListFragment: [#InlineListFragment],
     value: Raw.t,

--- a/snapshot_tests/operations/expected/native/generate/fragmentInFragment.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/fragmentInFragment.res.txt
@@ -32,45 +32,41 @@ function back to the original JSON-compatible data ")
 nullableOfNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      {nullableOfNullable: nullableOfNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable: nullableOfNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment: [#ListFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -119,59 +115,55 @@ nullableOfNullable
 ",
     ListFragment.query,
   )
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "nullableOfNullable"))
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      listFragment: {
-        let value = (Obj.magic(value): ListFragment.Raw.t)
-
-        ListFragment.verifyArgsAndParse(~fragmentName=#ListFragment, value)
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t =>
-      Obj.magic(
-        Js.Array2.reduce(
-          [(Obj.magic(ListFragment.serialize((value: t).listFragment)): Js.Json.t)],
-          Graphql_ppx_runtime.deepMerge,
-          (
-            Obj.magic({
-              let nullableOfNullable = {
-                let value = (value: t).nullableOfNullable
-                switch value {
-                | Some(value) =>
-                  Js.Nullable.return(
-                    Js.Array2.map(value, value =>
-                      switch value {
-                      | Some(value) => Js.Nullable.return(value)
-                      | None => Js.Nullable.null
-                      }
-                    ),
-                  )
-                | None => Js.Nullable.null
-                }
-              }
-              {"nullableOfNullable": nullableOfNullable}
-            }): Js.Json.t
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "nullableOfNullable"))
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
           ),
+        )
+      | None => None
+      }
+    },
+    listFragment: {
+      let value = (Obj.magic(value): ListFragment.Raw.t)
+
+      ListFragment.verifyArgsAndParse(~fragmentName=#ListFragment, value)
+    },
+  }
+  let serialize = (value): Raw.t =>
+    Obj.magic(
+      Js.Array2.reduce(
+        [(Obj.magic(ListFragment.serialize((value: t).listFragment)): Js.Json.t)],
+        Graphql_ppx_runtime.deepMerge,
+        (
+          Obj.magic({
+            let nullableOfNullable = {
+              let value = (value: t).nullableOfNullable
+              switch value {
+              | Some(value) =>
+                Js.Nullable.return(
+                  Js.Array2.map(value, value =>
+                    switch value {
+                    | Some(value) => Js.Nullable.return(value)
+                    | None => Js.Nullable.null
+                    }
+                  ),
+                )
+              | None => Js.Nullable.null
+              }
+            }
+            {"nullableOfNullable": nullableOfNullable}
+          }): Js.Json.t
         ),
-      ): t => Raw.t
-  )
+      ),
+    )
   let verifyArgsAndParse = (~fragmentName as _Another: [#Another], value: Raw.t) => parse(value)
   let verifyName = x => switch x {
   | #Another => ()

--- a/snapshot_tests/operations/expected/native/generate/fragmentOnInterface.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/fragmentOnInterface.res.txt
@@ -45,23 +45,19 @@ __typename
 id  
 }
 "
-  let parse = (
-    (value): t => {
-      id: {
-        let value = (value: Raw.t).id
-        value
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let id = {
-        let value = (value: t).id
-        value
-      }
-      {id: id}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    id: {
+      let value = (value: Raw.t).id
+      value
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let id = {
+      let value = (value: t).id
+      value
+    }
+    {id: id}
+  }
   let verifyArgsAndParse = (
     ~fragmentName as _InterfaceFragment: [#InterfaceFragment],
     value: Raw.t,
@@ -119,37 +115,33 @@ id
 ",
     InterfaceFragment.query,
   )
-  let parse = (
-    (value): t => {
-      id: {
-        let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "id"))
-        value
-      },
-      interfaceFragment: {
-        let value = (Obj.magic(value): InterfaceFragment.Raw.t)
+  let parse = (value): t => {
+    id: {
+      let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "id"))
+      value
+    },
+    interfaceFragment: {
+      let value = (Obj.magic(value): InterfaceFragment.Raw.t)
 
-        InterfaceFragment.verifyArgsAndParse(~fragmentName=#InterfaceFragment, value)
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t =>
-      Obj.magic(
-        Js.Array2.reduce(
-          [(Obj.magic(InterfaceFragment.serialize((value: t).interfaceFragment)): Js.Json.t)],
-          Graphql_ppx_runtime.deepMerge,
-          (
-            Obj.magic({
-              let id = {
-                let value = (value: t).id
-                value
-              }
-              {"id": id}
-            }): Js.Json.t
-          ),
+      InterfaceFragment.verifyArgsAndParse(~fragmentName=#InterfaceFragment, value)
+    },
+  }
+  let serialize = (value): Raw.t =>
+    Obj.magic(
+      Js.Array2.reduce(
+        [(Obj.magic(InterfaceFragment.serialize((value: t).interfaceFragment)): Js.Json.t)],
+        Graphql_ppx_runtime.deepMerge,
+        (
+          Obj.magic({
+            let id = {
+              let value = (value: t).id
+              value
+            }
+            {"id": id}
+          }): Js.Json.t
         ),
-      ): t => Raw.t
-  )
+      ),
+    )
   let verifyArgsAndParse = (~fragmentName as _AnotherFragment: [#AnotherFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -192,37 +184,33 @@ id
 ",
     InterfaceFragment.query,
   )
-  let parse = (
-    (value): t => {
-      id: {
-        let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "id"))
-        value
-      },
-      interfaceFragment: {
-        let value = (Obj.magic(value): InterfaceFragment.Raw.t)
+  let parse = (value): t => {
+    id: {
+      let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "id"))
+      value
+    },
+    interfaceFragment: {
+      let value = (Obj.magic(value): InterfaceFragment.Raw.t)
 
-        InterfaceFragment.verifyArgsAndParse(~fragmentName=#InterfaceFragment, value)
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t =>
-      Obj.magic(
-        Js.Array2.reduce(
-          [(Obj.magic(InterfaceFragment.serialize((value: t).interfaceFragment)): Js.Json.t)],
-          Graphql_ppx_runtime.deepMerge,
-          (
-            Obj.magic({
-              let id = {
-                let value = (value: t).id
-                value
-              }
-              {"id": id}
-            }): Js.Json.t
-          ),
+      InterfaceFragment.verifyArgsAndParse(~fragmentName=#InterfaceFragment, value)
+    },
+  }
+  let serialize = (value): Raw.t =>
+    Obj.magic(
+      Js.Array2.reduce(
+        [(Obj.magic(InterfaceFragment.serialize((value: t).interfaceFragment)): Js.Json.t)],
+        Graphql_ppx_runtime.deepMerge,
+        (
+          Obj.magic({
+            let id = {
+              let value = (value: t).id
+              value
+            }
+            {"id": id}
+          }): Js.Json.t
         ),
-      ): t => Raw.t
-  )
+      ),
+    )
   let verifyArgsAndParse = (~fragmentName as _AnonUser: [#AnonUser], value: Raw.t) => parse(value)
   let verifyName = x => switch x {
   | #AnonUser => ()

--- a/snapshot_tests/operations/expected/native/generate/fragmentUnion.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/fragmentUnion.res.txt
@@ -37,23 +37,19 @@ function back to the original JSON-compatible data ")
 name  
 }
 "
-  let parse = (
-    (value): t => {
-      name: {
-        let value = (value: Raw.t).name
-        value
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let name = {
-        let value = (value: t).name
-        value
-      }
-      {name: name}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    name: {
+      let value = (value: Raw.t).name
+      value
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let name = {
+      let value = (value: t).name
+      value
+    }
+    {name: name}
+  }
   let verifyArgsAndParse = (~fragmentName as _DogFragment: [#DogFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -92,23 +88,19 @@ function back to the original JSON-compatible data ")
 name  
 }
 "
-  let parse = (
-    (value): t => {
-      name: {
-        let value = (value: Raw.t).name
-        value
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let name = {
-        let value = (value: t).name
-        value
-      }
-      {name: name}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    name: {
+      let value = (value: Raw.t).name
+      value
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let name = {
+      let value = (value: t).name
+      value
+    }
+    {name: name}
+  }
   let verifyArgsAndParse = (~fragmentName as _HumanFragment: [#HumanFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/native/generate/fragmentUnion.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/fragmentUnion.res.txt
@@ -1,9 +1,11 @@
 module Graphql_ppx_runtime = {
   // mock
-  let assign_typename: (
-    Js.Json.t,
-    string,
-  ) => Js.Json.t = %raw(` (obj, typename) => { obj.__typename = typename; return obj } `)
+  let assign_typename: (Js.Json.t, string) => Js.Json.t = (
+    %raw(` (obj, typename) => { obj.__typename = typename; return obj } `): (
+      Js.Json.t,
+      string,
+    ) => Js.Json.t
+  )
 }
 module DogFragment: {
   @@ocaml.warning("-32-30")

--- a/snapshot_tests/operations/expected/native/generate/fragmentWithdifferentReturnType.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/fragmentWithdifferentReturnType.res.txt
@@ -41,59 +41,55 @@ nullableOfNullable
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment: [#ListFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/native/generate/fragmentvariableinput.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/fragmentvariableinput.res.txt
@@ -35,54 +35,50 @@ id
 
 }
 "
-  let parse = (
-    (value): t => {
-      reposts: {
-        let value = (value: Raw.t).reposts
-        Js.Array2.map(value, value =>
-          switch Js.toOption(value) {
-          | Some(value) =>
-            Some(
-              (
-                {
-                  id: {
-                    let value = (value: Raw.t_reposts).id
-                    value
-                  },
-                }: t_reposts
-              ),
-            )
-          | None => None
-          }
-        )
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let reposts = {
-        let value = (value: t).reposts
-        Js.Array2.map(value, value =>
-          switch value {
-          | Some(value) =>
-            Js.Nullable.return(
-              (
-                {
-                  let id = {
-                    let value = (value: t_reposts).id
-                    value
-                  }
-                  {id: id}
-                }: Raw.t_reposts
-              ),
-            )
-          | None => Js.Nullable.null
-          }
-        )
-      }
-      {reposts: reposts}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    reposts: {
+      let value = (value: Raw.t).reposts
+      Js.Array2.map(value, value =>
+        switch Js.toOption(value) {
+        | Some(value) =>
+          Some(
+            (
+              {
+                id: {
+                  let value = (value: Raw.t_reposts).id
+                  value
+                },
+              }: t_reposts
+            ),
+          )
+        | None => None
+        }
+      )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let reposts = {
+      let value = (value: t).reposts
+      Js.Array2.map(value, value =>
+        switch value {
+        | Some(value) =>
+          Js.Nullable.return(
+            (
+              {
+                let id = {
+                  let value = (value: t_reposts).id
+                  value
+                }
+                {id: id}
+              }: Raw.t_reposts
+            ),
+          )
+        | None => Js.Nullable.null
+        }
+      )
+    }
+    {reposts: reposts}
+  }
   let verifyArgsAndParse = (
     ~name as _name: [#NonNull_String],
     ~fragmentName as _test: [#test],

--- a/snapshot_tests/operations/expected/native/generate/hasuraRepro.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/hasuraRepro.res.txt
@@ -28,23 +28,19 @@ function back to the original JSON-compatible data ")
 name  
 }
 "
-  let parse = (
-    (value): t => {
-      name: {
-        let value = (value: Raw.t).name
-        value
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let name = {
-        let value = (value: t).name
-        value
-      }
-      {name: name}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    name: {
+      let value = (value: Raw.t).name
+      value
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let name = {
+      let value = (value: t).name
+      value
+    }
+    {name: name}
+  }
   let verifyArgsAndParse = (~fragmentName as _Dog: [#Dog], value: Raw.t) => parse(value)
   let verifyName = x => switch x {
   | #Dog => ()

--- a/snapshot_tests/operations/expected/native/generate/hasuraRepro.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/hasuraRepro.res.txt
@@ -118,22 +118,24 @@ hasuraRepro(orderBy: [{id: desc}], block: {number: $blockNumber, type: $type})  
     }
     {hasuraRepro: hasuraRepro}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    blockNumber: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).blockNumber),
-    type_: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).type_),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      blockNumber: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).blockNumber),
+      type_: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).type_),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~blockNumber=?, ~type_=?, ()): t_variables => {blockNumber, type_}
   let makeDefaultVariables = () => makeVariables()
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"

--- a/snapshot_tests/operations/expected/native/generate/listsArgs.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/listsArgs.res.txt
@@ -68,51 +68,53 @@ listsInput(arg: {nullableOfNullable: $nullableOfNullable, nullableOfNonNullable:
     }
     {listsInput: listsInput}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    nullableOfNullable: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      nullableOfNullable: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables).nullableOfNullable),
+      nullableOfNonNullable: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => Js.Array2.map(a, b => (a => a)(b)))(b))
+          }
+      )((inp: t_variables).nullableOfNonNullable),
+      nonNullableOfNullable: (
+        a =>
+          Js.Array2.map(a, b =>
             (
               a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
+                switch a {
+                | None => Js.Nullable.undefined
+                | Some(b) => Js.Nullable.return((a => a)(b))
+                }
+            )(b)
           )
-        }
-    )((inp: t_variables).nullableOfNullable),
-    nullableOfNonNullable: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => Js.Array2.map(a, b => (a => a)(b)))(b))
-        }
-    )((inp: t_variables).nullableOfNonNullable),
-    nonNullableOfNullable: (
-      a =>
-        Js.Array2.map(a, b =>
-          (
-            a =>
-              switch a {
-              | None => Js.Nullable.undefined
-              | Some(b) => Js.Nullable.return((a => a)(b))
-              }
-          )(b)
-        )
-    )((inp: t_variables).nonNullableOfNullable),
-    nonNullableOfNonNullable: (a => Js.Array2.map(a, b => (a => a)(b)))(
-      (inp: t_variables).nonNullableOfNonNullable,
-    ),
-  }
+      )((inp: t_variables).nonNullableOfNullable),
+      nonNullableOfNonNullable: (a => Js.Array2.map(a, b => (a => a)(b)))(
+        (inp: t_variables).nonNullableOfNonNullable,
+      ),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (
     ~nullableOfNullable=?,
     ~nullableOfNonNullable=?,

--- a/snapshot_tests/operations/expected/native/generate/listsInput.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/listsInput.res.txt
@@ -74,54 +74,58 @@ listsInput(arg: $arg)
     }
     {listsInput: listsInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectListsInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectListsInput: t_variables_ListsInput => Raw.t_variables_ListsInput = inp => {
-    nullableOfNullable: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectListsInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectListsInput: t_variables_ListsInput => Raw.t_variables_ListsInput = (
+    inp => {
+      nullableOfNullable: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_ListsInput).nullableOfNullable),
+      nullableOfNonNullable: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => Js.Array2.map(a, b => (a => a)(b)))(b))
+          }
+      )((inp: t_variables_ListsInput).nullableOfNonNullable),
+      nonNullableOfNullable: (
+        a =>
+          Js.Array2.map(a, b =>
             (
               a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
+                switch a {
+                | None => Js.Nullable.undefined
+                | Some(b) => Js.Nullable.return((a => a)(b))
+                }
+            )(b)
           )
-        }
-    )((inp: t_variables_ListsInput).nullableOfNullable),
-    nullableOfNonNullable: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => Js.Array2.map(a, b => (a => a)(b)))(b))
-        }
-    )((inp: t_variables_ListsInput).nullableOfNonNullable),
-    nonNullableOfNullable: (
-      a =>
-        Js.Array2.map(a, b =>
-          (
-            a =>
-              switch a {
-              | None => Js.Nullable.undefined
-              | Some(b) => Js.Nullable.return((a => a)(b))
-              }
-          )(b)
-        )
-    )((inp: t_variables_ListsInput).nonNullableOfNullable),
-    nonNullableOfNonNullable: (a => Js.Array2.map(a, b => (a => a)(b)))(
-      (inp: t_variables_ListsInput).nonNullableOfNonNullable,
-    ),
-  }
+      )((inp: t_variables_ListsInput).nonNullableOfNullable),
+      nonNullableOfNonNullable: (a => Js.Array2.map(a, b => (a => a)(b)))(
+        (inp: t_variables_ListsInput).nonNullableOfNonNullable,
+      ),
+    }: t_variables_ListsInput => Raw.t_variables_ListsInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectListsInput = (
     ~nullableOfNullable=?,

--- a/snapshot_tests/operations/expected/native/generate/module_type.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/module_type.res.txt
@@ -263,8 +263,10 @@ and VariousScalars: {
   let parse = (nestedObject: MyQueryRecursive.t_nestedObject) => {
     otherInner: nestedObject.inner,
   }
-  let serialize: t => MyQueryRecursive.t_nestedObject = t => {
-    inner: t.otherInner,
-  }
+  let serialize: t => MyQueryRecursive.t_nestedObject = (
+    t => {
+      inner: t.otherInner,
+    }: t => MyQueryRecursive.t_nestedObject
+  )
 }
 

--- a/snapshot_tests/operations/expected/native/generate/mutationWithArgs.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/mutationWithArgs.res.txt
@@ -42,9 +42,9 @@ optionalInputArgs(required: $required, anotherRequired: "val")
     }
     {optionalInputArgs: optionalInputArgs}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    required: (a => a)((inp: t_variables).required),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {required: (a => a)((inp: t_variables).required)}: t_variables => Raw.t_variables
+  )
   let makeVariables = (~required, ()): t_variables => {required: required}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/native/generate/mutationWithArgsAndNoRecords.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/mutationWithArgsAndNoRecords.res.txt
@@ -42,9 +42,9 @@ optionalInputArgs(required: $required, anotherRequired: "val")
     }
     {optionalInputArgs: optionalInputArgs}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    required: (a => a)((inp: t_variables).required),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {required: (a => a)((inp: t_variables).required)}: t_variables => Raw.t_variables
+  )
   let makeVariables = (~required, ()): t_variables => {required: required}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/native/generate/nonrecursiveInput.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/nonrecursiveInput.res.txt
@@ -90,95 +90,101 @@ nonrecursiveInput(arg: $arg)
     }
     {nonrecursiveInput: nonrecursiveInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = inp => {
-    nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
-    nullableArray: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).nullableArray),
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).field),
-    enum: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                switch a {
-                | #FIRST => "FIRST"
-                | #SECOND => "SECOND"
-                | #THIRD => "THIRD"
-                }
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).enum),
-    embeddedInput: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) =>
-                        Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).embeddedInput),
-    custom: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).custom),
-  }
-  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = inp => {
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_EmbeddedInput).field),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = (
+    inp => {
+      nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
+      nullableArray: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).nullableArray),
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).field),
+      enum: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  switch a {
+                  | #FIRST => "FIRST"
+                  | #SECOND => "SECOND"
+                  | #THIRD => "THIRD"
+                  }
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).enum),
+      embeddedInput: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) =>
+                          Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).embeddedInput),
+      custom: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).custom),
+    }: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput
+  )
+  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = (
+    inp => {
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_EmbeddedInput).field),
+    }: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectNonrecursiveInput = (
     ~nonNullableField,
@@ -315,96 +321,102 @@ more: scalarsInput(arg: $arg2)
     }
     {scalarsInput, more}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
-    arg2: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg2),
-  }
-  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = inp => {
-    nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
-    nullableArray: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).nullableArray),
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).field),
-    enum: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                switch a {
-                | #FIRST => "FIRST"
-                | #SECOND => "SECOND"
-                | #THIRD => "THIRD"
-                }
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).enum),
-    embeddedInput: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) =>
-                        Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).embeddedInput),
-    custom: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).custom),
-  }
-  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = inp => {
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_EmbeddedInput).field),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
+      arg2: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg2),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = (
+    inp => {
+      nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
+      nullableArray: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).nullableArray),
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).field),
+      enum: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  switch a {
+                  | #FIRST => "FIRST"
+                  | #SECOND => "SECOND"
+                  | #THIRD => "THIRD"
+                  }
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).enum),
+      embeddedInput: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) =>
+                          Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).embeddedInput),
+      custom: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).custom),
+    }: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput
+  )
+  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = (
+    inp => {
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_EmbeddedInput).field),
+    }: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput
+  )
   let makeVariables = (~arg, ~arg2, ()): t_variables => {arg, arg2}
   and makeInputObjectNonrecursiveInput = (
     ~nonNullableField,

--- a/snapshot_tests/operations/expected/native/generate/pokedexScalars.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/pokedexScalars.res.txt
@@ -101,22 +101,24 @@ name
     }
     {pokemon: pokemon}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    id: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).id),
-    name: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).name),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      id: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).id),
+      name: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).name),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~id=?, ~name=?, ()): t_variables => {id, name}
   let makeDefaultVariables = () => makeVariables()
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
@@ -226,22 +228,24 @@ name
     }
     {pokemon: pokemon}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    id: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).id),
-    name: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).name),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      id: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).id),
+      name: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).name),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~id=?, ~name=?, ()): t_variables => {id, name}
   let makeDefaultVariables = () => makeVariables()
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"

--- a/snapshot_tests/operations/expected/native/generate/record.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/record.res.txt
@@ -333,31 +333,27 @@ string
 int  
 }
 "
-    let parse = (
-      (value): t => {
-        string: {
-          let value = (value: Raw.t).string
-          value
-        },
-        int: {
-          let value = (value: Raw.t).int
-          value
-        },
-      }: Raw.t => t
-    )
-    let serialize = (
-      (value): Raw.t => {
-        let int = {
-          let value = (value: t).int
-          value
-        }
-        and string = {
-          let value = (value: t).string
-          value
-        }
-        {string, int}
-      }: t => Raw.t
-    )
+    let parse = (value): t => {
+      string: {
+        let value = (value: Raw.t).string
+        value
+      },
+      int: {
+        let value = (value: Raw.t).int
+        value
+      },
+    }
+    let serialize = (value): Raw.t => {
+      let int = {
+        let value = (value: t).int
+        value
+      }
+      and string = {
+        let value = (value: t).string
+        value
+      }
+      {string, int}
+    }
     let verifyArgsAndParse = (~fragmentName as _Fragment: [#Fragment], value: Raw.t) => parse(value)
     let verifyName = x => switch x {
     | #Fragment => ()
@@ -600,39 +596,35 @@ name
 barkVolume  
 }
 "
-    let parse = (
-      (value): t => {
-        __typename: {
-          let value = (value: Raw.t).__typename
-          value
-        },
-        name: {
-          let value = (value: Raw.t).name
-          value
-        },
-        barkVolume: {
-          let value = (value: Raw.t).barkVolume
-          value
-        },
-      }: Raw.t => t
-    )
-    let serialize = (
-      (value): Raw.t => {
-        let barkVolume = {
-          let value = (value: t).barkVolume
-          value
-        }
-        and name = {
-          let value = (value: t).name
-          value
-        }
-        and __typename = {
-          let value = (value: t).__typename
-          value
-        }
-        {__typename, name, barkVolume}
-      }: t => Raw.t
-    )
+    let parse = (value): t => {
+      __typename: {
+        let value = (value: Raw.t).__typename
+        value
+      },
+      name: {
+        let value = (value: Raw.t).name
+        value
+      },
+      barkVolume: {
+        let value = (value: Raw.t).barkVolume
+        value
+      },
+    }
+    let serialize = (value): Raw.t => {
+      let barkVolume = {
+        let value = (value: t).barkVolume
+        value
+      }
+      and name = {
+        let value = (value: t).name
+        value
+      }
+      and __typename = {
+        let value = (value: t).__typename
+        value
+      }
+      {__typename, name, barkVolume}
+    }
     let verifyArgsAndParse = (~fragmentName as _DogFragment: [#DogFragment], value: Raw.t) =>
       parse(value)
     let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/native/generate/recursiveInput.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/recursiveInput.res.txt
@@ -69,42 +69,46 @@ recursiveInput(arg: $arg)
     }
     {recursiveInput: recursiveInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectRecursiveInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectRecursiveInput: t_variables_RecursiveInput => Raw.t_variables_RecursiveInput = inp => {
-    otherField: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_RecursiveInput).otherField),
-    inner: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => serializeInputObjectRecursiveInput(a))(b))
-        }
-    )((inp: t_variables_RecursiveInput).inner),
-    enum: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                switch a {
-                | #FIRST => "FIRST"
-                | #SECOND => "SECOND"
-                | #THIRD => "THIRD"
-                }
-            )(b),
-          )
-        }
-    )((inp: t_variables_RecursiveInput).enum),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectRecursiveInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectRecursiveInput: t_variables_RecursiveInput => Raw.t_variables_RecursiveInput = (
+    inp => {
+      otherField: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_RecursiveInput).otherField),
+      inner: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => serializeInputObjectRecursiveInput(a))(b))
+          }
+      )((inp: t_variables_RecursiveInput).inner),
+      enum: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  switch a {
+                  | #FIRST => "FIRST"
+                  | #SECOND => "SECOND"
+                  | #THIRD => "THIRD"
+                  }
+              )(b),
+            )
+          }
+      )((inp: t_variables_RecursiveInput).enum),
+    }: t_variables_RecursiveInput => Raw.t_variables_RecursiveInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectRecursiveInput = (
     ~otherField=?,
@@ -200,37 +204,45 @@ recursiveRepro(input: $input)
     }
     {recursiveRepro: recursiveRepro}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    input: (a => serializeInputObjectproblem_input(a))((inp: t_variables).input),
-  }
-  and serializeInputObjectproblem_input: t_variables_problem_input => Raw.t_variables_problem_input = inp => {
-    the_problem: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => serializeInputObjectthis_will_be_duplicated(a))(b))
-        }
-    )((inp: t_variables_problem_input).the_problem),
-    b: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => serializeInputObjectnested_type(a))(b))
-        }
-    )((inp: t_variables_problem_input).b),
-  }
-  and serializeInputObjectthis_will_be_duplicated: t_variables_this_will_be_duplicated => Raw.t_variables_this_will_be_duplicated = inp => {
-    id: (a => a)((inp: t_variables_this_will_be_duplicated).id),
-  }
-  and serializeInputObjectnested_type: t_variables_nested_type => Raw.t_variables_nested_type = inp => {
-    the_problem: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => serializeInputObjectthis_will_be_duplicated(a))(b))
-        }
-    )((inp: t_variables_nested_type).the_problem),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      input: (a => serializeInputObjectproblem_input(a))((inp: t_variables).input),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectproblem_input: t_variables_problem_input => Raw.t_variables_problem_input = (
+    inp => {
+      the_problem: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => serializeInputObjectthis_will_be_duplicated(a))(b))
+          }
+      )((inp: t_variables_problem_input).the_problem),
+      b: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => serializeInputObjectnested_type(a))(b))
+          }
+      )((inp: t_variables_problem_input).b),
+    }: t_variables_problem_input => Raw.t_variables_problem_input
+  )
+  and serializeInputObjectthis_will_be_duplicated: t_variables_this_will_be_duplicated => Raw.t_variables_this_will_be_duplicated = (
+    inp => {
+      id: (a => a)((inp: t_variables_this_will_be_duplicated).id),
+    }: t_variables_this_will_be_duplicated => Raw.t_variables_this_will_be_duplicated
+  )
+  and serializeInputObjectnested_type: t_variables_nested_type => Raw.t_variables_nested_type = (
+    inp => {
+      the_problem: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => serializeInputObjectthis_will_be_duplicated(a))(b))
+          }
+      )((inp: t_variables_nested_type).the_problem),
+    }: t_variables_nested_type => Raw.t_variables_nested_type
+  )
   let makeVariables = (~input, ()): t_variables => {input: input}
   and makeInputObjectproblem_input = (~the_problem=?, ~b=?, ()): t_variables_problem_input => {
     the_problem,

--- a/snapshot_tests/operations/expected/native/generate/scalarsArgs.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/scalarsArgs.res.txt
@@ -98,48 +98,50 @@ scalarsInput(arg: {nullableString: $nullableString, string: $string, nullableInt
     }
     {scalarsInput: scalarsInput}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    nullableString: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableString),
-    string: (a => a)((inp: t_variables).string),
-    nullableInt: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableInt),
-    int: (a => a)((inp: t_variables).int),
-    nullableFloat: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableFloat),
-    float: (a => a)((inp: t_variables).float),
-    nullableBoolean: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableBoolean),
-    boolean: (a => a)((inp: t_variables).boolean),
-    nullableID: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableID),
-    id: (a => a)((inp: t_variables).id),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      nullableString: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableString),
+      string: (a => a)((inp: t_variables).string),
+      nullableInt: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableInt),
+      int: (a => a)((inp: t_variables).int),
+      nullableFloat: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableFloat),
+      float: (a => a)((inp: t_variables).float),
+      nullableBoolean: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableBoolean),
+      boolean: (a => a)((inp: t_variables).boolean),
+      nullableID: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableID),
+      id: (a => a)((inp: t_variables).id),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (
     ~nullableString=?,
     ~string,

--- a/snapshot_tests/operations/expected/native/generate/scalarsInput.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/scalarsInput.res.txt
@@ -104,51 +104,55 @@ scalarsInput(arg: $arg)
     }
     {scalarsInput: scalarsInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectVariousScalarsInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectVariousScalarsInput: t_variables_VariousScalarsInput => Raw.t_variables_VariousScalarsInput = inp => {
-    nullableString: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableString),
-    string: (a => a)((inp: t_variables_VariousScalarsInput).string),
-    nullableInt: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableInt),
-    int: (a => a)((inp: t_variables_VariousScalarsInput).int),
-    nullableFloat: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableFloat),
-    float: (a => a)((inp: t_variables_VariousScalarsInput).float),
-    nullableBoolean: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableBoolean),
-    boolean: (a => a)((inp: t_variables_VariousScalarsInput).boolean),
-    nullableID: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableID),
-    id: (a => a)((inp: t_variables_VariousScalarsInput).id),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectVariousScalarsInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectVariousScalarsInput: t_variables_VariousScalarsInput => Raw.t_variables_VariousScalarsInput = (
+    inp => {
+      nullableString: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableString),
+      string: (a => a)((inp: t_variables_VariousScalarsInput).string),
+      nullableInt: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableInt),
+      int: (a => a)((inp: t_variables_VariousScalarsInput).int),
+      nullableFloat: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableFloat),
+      float: (a => a)((inp: t_variables_VariousScalarsInput).float),
+      nullableBoolean: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableBoolean),
+      boolean: (a => a)((inp: t_variables_VariousScalarsInput).boolean),
+      nullableID: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableID),
+      id: (a => a)((inp: t_variables_VariousScalarsInput).id),
+    }: t_variables_VariousScalarsInput => Raw.t_variables_VariousScalarsInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectVariousScalarsInput = (
     ~nullableString=?,

--- a/snapshot_tests/operations/expected/native/generate/skipDirectives.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/skipDirectives.res.txt
@@ -164,9 +164,9 @@ string @include(if: $var)
     }
     {v1, v2}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    var: (a => a)((inp: t_variables).var),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {var: (a => a)((inp: t_variables).var)}: t_variables => Raw.t_variables
+  )
   let makeVariables = (~var, ()): t_variables => {var: var}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/native/generate/tagged_template.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/tagged_template.res.txt
@@ -1545,59 +1545,55 @@ nullableOfNonNullable
     ],
     [],
   )
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment: [#ListFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -1847,59 +1843,55 @@ nullableOfNonNullable
     ],
     [],
   )
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment8: [#ListFragment8], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/native/generate/union.res.txt
+++ b/snapshot_tests/operations/expected/native/generate/union.res.txt
@@ -541,31 +541,27 @@ name
 __typename  
 }
 "
-    let parse = (
-      (value): named => {
-        name: {
-          let value = (value: Raw.t).name
-          value
-        },
-        __typename: {
-          let value = (value: Raw.t).__typename
-          value
-        },
-      }: Raw.t => named
-    )
-    let serialize = (
-      (value): Raw.t => {
-        let __typename = {
-          let value = (value: named).__typename
-          value
-        }
-        and name = {
-          let value = (value: named).name
-          value
-        }
-        {name, __typename}
-      }: named => Raw.t
-    )
+    let parse = (value): named => {
+      name: {
+        let value = (value: Raw.t).name
+        value
+      },
+      __typename: {
+        let value = (value: Raw.t).__typename
+        value
+      },
+    }
+    let serialize = (value): Raw.t => {
+      let __typename = {
+        let value = (value: named).__typename
+        value
+      }
+      and name = {
+        let value = (value: named).name
+        value
+      }
+      {name, __typename}
+    }
     let verifyArgsAndParse = (~fragmentName as _DogFields: [#DogFields], value: Raw.t) =>
       parse(value)
     let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/records/generate/argNamedQuery.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/argNamedQuery.res.txt
@@ -42,9 +42,9 @@ argNamedQuery(query: $query)
     }
     {argNamedQuery: argNamedQuery}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    query: (a => a)((inp: t_variables).query),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {query: (a => a)((inp: t_variables).query)}: t_variables => Raw.t_variables
+  )
   let makeVariables = (~query, ()): t_variables => {query: query}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"
@@ -95,9 +95,9 @@ argNamedQuery(query: $query)
       }
       {argNamedQuery: argNamedQuery}
     }
-    let serializeVariables: t_variables => Raw.t_variables = inp => {
-      query: (a => a)((inp: t_variables).query),
-    }
+    let serializeVariables: t_variables => Raw.t_variables = (
+      inp => {query: (a => a)((inp: t_variables).query)}: t_variables => Raw.t_variables
+    )
     let makeVariables = (~query, ()): t_variables => {query: query}
     external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
     external toJson: Raw.t => Js.Json.t = "%identity"
@@ -147,9 +147,9 @@ argNamedQuery(query: $query)
       }
       {argNamedQuery: argNamedQuery}
     }
-    let serializeVariables: t_variables => Raw.t_variables = inp => {
-      query: (a => a)((inp: t_variables).query),
-    }
+    let serializeVariables: t_variables => Raw.t_variables = (
+      inp => {query: (a => a)((inp: t_variables).query)}: t_variables => Raw.t_variables
+    )
     let makeVariables = (~query, ()): t_variables => {query: query}
     external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
     external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/records/generate/comment.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/comment.res.txt
@@ -90,95 +90,101 @@ nonrecursiveInput(arg: $arg)
     }
     {nonrecursiveInput: nonrecursiveInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = inp => {
-    nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
-    nullableArray: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).nullableArray),
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).field),
-    enum: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                switch a {
-                | #FIRST => "FIRST"
-                | #SECOND => "SECOND"
-                | #THIRD => "THIRD"
-                }
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).enum),
-    embeddedInput: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) =>
-                        Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).embeddedInput),
-    custom: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).custom),
-  }
-  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = inp => {
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_EmbeddedInput).field),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = (
+    inp => {
+      nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
+      nullableArray: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).nullableArray),
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).field),
+      enum: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  switch a {
+                  | #FIRST => "FIRST"
+                  | #SECOND => "SECOND"
+                  | #THIRD => "THIRD"
+                  }
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).enum),
+      embeddedInput: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) =>
+                          Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).embeddedInput),
+      custom: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).custom),
+    }: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput
+  )
+  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = (
+    inp => {
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_EmbeddedInput).field),
+    }: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectNonrecursiveInput = (
     ~nonNullableField,

--- a/snapshot_tests/operations/expected/records/generate/customScalars.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/customScalars.res.txt
@@ -88,16 +88,18 @@ nonNullable
     }
     {customScalarField: customScalarField}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    opt: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).opt),
-    req: (a => a)((inp: t_variables).req),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      opt: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).opt),
+      req: (a => a)((inp: t_variables).req),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~opt=?, ~req, ()): t_variables => {opt, req}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/records/generate/customTypes.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/customTypes.res.txt
@@ -25,21 +25,25 @@ module NullableString = {
     | Red
     | Green
     | Blue
-  let parse: option<string> => t = color =>
-    switch color {
-    | Some("green") => Green
-    | Some("blue") => Blue
-    | Some("red") => Red
-    | Some(_)
-    | None =>
-      Red
-    }
-  let serialize: t => option<string> = color =>
-    switch color {
-    | Red => Some("red")
-    | Green => Some("green")
-    | Blue => Some("blue")
-    }
+  let parse: option<string> => t = (
+    color =>
+      switch color {
+      | Some("green") => Green
+      | Some("blue") => Blue
+      | Some("red") => Red
+      | Some(_)
+      | None =>
+        Red
+      }: option<string> => t
+  )
+  let serialize: t => option<string> = (
+    color =>
+      switch color {
+      | Red => Some("red")
+      | Green => Some("green")
+      | Blue => Some("blue")
+      }: t => option<string>
+  )
 }
 
 module DateTime = {

--- a/snapshot_tests/operations/expected/records/generate/enumInput.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/enumInput.res.txt
@@ -42,16 +42,18 @@ enumInput(arg: $arg)
     }
     {enumInput: enumInput}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (
-      a =>
-        switch a {
-        | #FIRST => "FIRST"
-        | #SECOND => "SECOND"
-        | #THIRD => "THIRD"
-        }
-    )((inp: t_variables).arg),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (
+        a =>
+          switch a {
+          | #FIRST => "FIRST"
+          | #SECOND => "SECOND"
+          | #THIRD => "THIRD"
+          }
+      )((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/records/generate/ewert_reproduction.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/ewert_reproduction.res.txt
@@ -49,60 +49,56 @@ lastname
 
 }
 "
-  let parse = (
-    (value): t => {
-      user: {
-        let value = (value: Raw.t).user
-        (
-          {
-            id: {
-              let value = (value: Raw.t_user).id
-              value
-            },
-            firstname: {
-              let value = (value: Raw.t_user).firstname
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            },
-            lastname: {
-              let value = (value: Raw.t_user).lastname
-              value
-            },
-          }: t_user
-        )
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let user = {
-        let value = (value: t).user
-        (
-          {
-            let lastname = {
-              let value = (value: t_user).lastname
-              value
+  let parse = (value): t => {
+    user: {
+      let value = (value: Raw.t).user
+      (
+        {
+          id: {
+            let value = (value: Raw.t_user).id
+            value
+          },
+          firstname: {
+            let value = (value: Raw.t_user).firstname
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
             }
-            and firstname = {
-              let value = (value: t_user).firstname
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
+          },
+          lastname: {
+            let value = (value: Raw.t_user).lastname
+            value
+          },
+        }: t_user
+      )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let user = {
+      let value = (value: t).user
+      (
+        {
+          let lastname = {
+            let value = (value: t_user).lastname
+            value
+          }
+          and firstname = {
+            let value = (value: t_user).firstname
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
             }
-            and id = {
-              let value = (value: t_user).id
-              value
-            }
-            {id, firstname, lastname}
-          }: Raw.t_user
-        )
-      }
-      {user: user}
-    }: t => Raw.t
-  )
+          }
+          and id = {
+            let value = (value: t_user).id
+            value
+          }
+          {id, firstname, lastname}
+        }: Raw.t_user
+      )
+    }
+    {user: user}
+  }
   let verifyArgsAndParse = (
     ~userId as _userId: [#NonNull_String],
     ~fragmentName as _UserData: [#UserData],

--- a/snapshot_tests/operations/expected/records/generate/fragmentDefinition.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/fragmentDefinition.res.txt
@@ -709,15 +709,17 @@ l5: lists  {
     }
     {l1, l2, l3, l4, l5}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg1: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).arg1),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg1: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).arg1),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~arg1=?, ()): t_variables => {arg1: arg1}
   let makeDefaultVariables = () => makeVariables()
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"

--- a/snapshot_tests/operations/expected/records/generate/fragmentDefinition.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/fragmentDefinition.res.txt
@@ -45,59 +45,55 @@ nullableOfNullable
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment: [#ListFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -136,29 +132,25 @@ function back to the original JSON-compatible data ")
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNonNullable: nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNonNullable: nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _Another: [#Another], value: Raw.t) => parse(value)
   let verifyName = x => switch x {
   | #Another => ()
@@ -196,45 +188,41 @@ function back to the original JSON-compatible data ")
 listWithArg(arg1: $arg1)  
 }
 "
-  let parse = (
-    (value): t => {
-      listWithArg: {
-        let value = (value: Raw.t).listWithArg
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let listWithArg = {
-        let value = (value: t).listWithArg
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    listWithArg: {
+      let value = (value: Raw.t).listWithArg
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      {listWithArg: listWithArg}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let listWithArg = {
+      let value = (value: t).listWithArg
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {listWithArg: listWithArg}
+  }
   let verifyArgsAndParse = (
     ~arg1 as _arg1: [#String],
     ~fragmentName as _FragmentWithArgs: [#FragmentWithArgs],
@@ -266,59 +254,55 @@ nullableOfNullable
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (
     ~fragmentName as _InlineListFragment: [#InlineListFragment],
     value: Raw.t,
@@ -349,59 +333,55 @@ nullableOfNullable
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (
     ~fragmentName as _InlineListFragment: [#InlineListFragment],
     value: Raw.t,

--- a/snapshot_tests/operations/expected/records/generate/fragmentInFragment.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/fragmentInFragment.res.txt
@@ -32,45 +32,41 @@ function back to the original JSON-compatible data ")
 nullableOfNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      {nullableOfNullable: nullableOfNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable: nullableOfNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment: [#ListFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -119,59 +115,55 @@ nullableOfNullable
 ",
     ListFragment.query,
   )
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "nullableOfNullable"))
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      listFragment: {
-        let value = (Obj.magic(value): ListFragment.Raw.t)
-
-        ListFragment.verifyArgsAndParse(~fragmentName=#ListFragment, value)
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t =>
-      Obj.magic(
-        Js.Array2.reduce(
-          [(Obj.magic(ListFragment.serialize((value: t).listFragment)): Js.Json.t)],
-          Graphql_ppx_runtime.deepMerge,
-          (
-            Obj.magic({
-              let nullableOfNullable = {
-                let value = (value: t).nullableOfNullable
-                switch value {
-                | Some(value) =>
-                  Js.Nullable.return(
-                    Js.Array2.map(value, value =>
-                      switch value {
-                      | Some(value) => Js.Nullable.return(value)
-                      | None => Js.Nullable.null
-                      }
-                    ),
-                  )
-                | None => Js.Nullable.null
-                }
-              }
-              {"nullableOfNullable": nullableOfNullable}
-            }): Js.Json.t
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "nullableOfNullable"))
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
           ),
+        )
+      | None => None
+      }
+    },
+    listFragment: {
+      let value = (Obj.magic(value): ListFragment.Raw.t)
+
+      ListFragment.verifyArgsAndParse(~fragmentName=#ListFragment, value)
+    },
+  }
+  let serialize = (value): Raw.t =>
+    Obj.magic(
+      Js.Array2.reduce(
+        [(Obj.magic(ListFragment.serialize((value: t).listFragment)): Js.Json.t)],
+        Graphql_ppx_runtime.deepMerge,
+        (
+          Obj.magic({
+            let nullableOfNullable = {
+              let value = (value: t).nullableOfNullable
+              switch value {
+              | Some(value) =>
+                Js.Nullable.return(
+                  Js.Array2.map(value, value =>
+                    switch value {
+                    | Some(value) => Js.Nullable.return(value)
+                    | None => Js.Nullable.null
+                    }
+                  ),
+                )
+              | None => Js.Nullable.null
+              }
+            }
+            {"nullableOfNullable": nullableOfNullable}
+          }): Js.Json.t
         ),
-      ): t => Raw.t
-  )
+      ),
+    )
   let verifyArgsAndParse = (~fragmentName as _Another: [#Another], value: Raw.t) => parse(value)
   let verifyName = x => switch x {
   | #Another => ()

--- a/snapshot_tests/operations/expected/records/generate/fragmentOnInterface.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/fragmentOnInterface.res.txt
@@ -45,23 +45,19 @@ __typename
 id  
 }
 "
-  let parse = (
-    (value): t => {
-      id: {
-        let value = (value: Raw.t).id
-        value
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let id = {
-        let value = (value: t).id
-        value
-      }
-      {id: id}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    id: {
+      let value = (value: Raw.t).id
+      value
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let id = {
+      let value = (value: t).id
+      value
+    }
+    {id: id}
+  }
   let verifyArgsAndParse = (
     ~fragmentName as _InterfaceFragment: [#InterfaceFragment],
     value: Raw.t,
@@ -119,37 +115,33 @@ id
 ",
     InterfaceFragment.query,
   )
-  let parse = (
-    (value): t => {
-      id: {
-        let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "id"))
-        value
-      },
-      interfaceFragment: {
-        let value = (Obj.magic(value): InterfaceFragment.Raw.t)
+  let parse = (value): t => {
+    id: {
+      let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "id"))
+      value
+    },
+    interfaceFragment: {
+      let value = (Obj.magic(value): InterfaceFragment.Raw.t)
 
-        InterfaceFragment.verifyArgsAndParse(~fragmentName=#InterfaceFragment, value)
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t =>
-      Obj.magic(
-        Js.Array2.reduce(
-          [(Obj.magic(InterfaceFragment.serialize((value: t).interfaceFragment)): Js.Json.t)],
-          Graphql_ppx_runtime.deepMerge,
-          (
-            Obj.magic({
-              let id = {
-                let value = (value: t).id
-                value
-              }
-              {"id": id}
-            }): Js.Json.t
-          ),
+      InterfaceFragment.verifyArgsAndParse(~fragmentName=#InterfaceFragment, value)
+    },
+  }
+  let serialize = (value): Raw.t =>
+    Obj.magic(
+      Js.Array2.reduce(
+        [(Obj.magic(InterfaceFragment.serialize((value: t).interfaceFragment)): Js.Json.t)],
+        Graphql_ppx_runtime.deepMerge,
+        (
+          Obj.magic({
+            let id = {
+              let value = (value: t).id
+              value
+            }
+            {"id": id}
+          }): Js.Json.t
         ),
-      ): t => Raw.t
-  )
+      ),
+    )
   let verifyArgsAndParse = (~fragmentName as _AnotherFragment: [#AnotherFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -192,37 +184,33 @@ id
 ",
     InterfaceFragment.query,
   )
-  let parse = (
-    (value): t => {
-      id: {
-        let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "id"))
-        value
-      },
-      interfaceFragment: {
-        let value = (Obj.magic(value): InterfaceFragment.Raw.t)
+  let parse = (value): t => {
+    id: {
+      let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "id"))
+      value
+    },
+    interfaceFragment: {
+      let value = (Obj.magic(value): InterfaceFragment.Raw.t)
 
-        InterfaceFragment.verifyArgsAndParse(~fragmentName=#InterfaceFragment, value)
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t =>
-      Obj.magic(
-        Js.Array2.reduce(
-          [(Obj.magic(InterfaceFragment.serialize((value: t).interfaceFragment)): Js.Json.t)],
-          Graphql_ppx_runtime.deepMerge,
-          (
-            Obj.magic({
-              let id = {
-                let value = (value: t).id
-                value
-              }
-              {"id": id}
-            }): Js.Json.t
-          ),
+      InterfaceFragment.verifyArgsAndParse(~fragmentName=#InterfaceFragment, value)
+    },
+  }
+  let serialize = (value): Raw.t =>
+    Obj.magic(
+      Js.Array2.reduce(
+        [(Obj.magic(InterfaceFragment.serialize((value: t).interfaceFragment)): Js.Json.t)],
+        Graphql_ppx_runtime.deepMerge,
+        (
+          Obj.magic({
+            let id = {
+              let value = (value: t).id
+              value
+            }
+            {"id": id}
+          }): Js.Json.t
         ),
-      ): t => Raw.t
-  )
+      ),
+    )
   let verifyArgsAndParse = (~fragmentName as _AnonUser: [#AnonUser], value: Raw.t) => parse(value)
   let verifyName = x => switch x {
   | #AnonUser => ()

--- a/snapshot_tests/operations/expected/records/generate/fragmentUnion.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/fragmentUnion.res.txt
@@ -37,23 +37,19 @@ function back to the original JSON-compatible data ")
 name  
 }
 "
-  let parse = (
-    (value): t => {
-      name: {
-        let value = (value: Raw.t).name
-        value
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let name = {
-        let value = (value: t).name
-        value
-      }
-      {name: name}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    name: {
+      let value = (value: Raw.t).name
+      value
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let name = {
+      let value = (value: t).name
+      value
+    }
+    {name: name}
+  }
   let verifyArgsAndParse = (~fragmentName as _DogFragment: [#DogFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -92,23 +88,19 @@ function back to the original JSON-compatible data ")
 name  
 }
 "
-  let parse = (
-    (value): t => {
-      name: {
-        let value = (value: Raw.t).name
-        value
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let name = {
-        let value = (value: t).name
-        value
-      }
-      {name: name}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    name: {
+      let value = (value: Raw.t).name
+      value
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let name = {
+      let value = (value: t).name
+      value
+    }
+    {name: name}
+  }
   let verifyArgsAndParse = (~fragmentName as _HumanFragment: [#HumanFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/records/generate/fragmentUnion.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/fragmentUnion.res.txt
@@ -1,9 +1,11 @@
 module Graphql_ppx_runtime = {
   // mock
-  let assign_typename: (
-    Js.Json.t,
-    string,
-  ) => Js.Json.t = %raw(` (obj, typename) => { obj.__typename = typename; return obj } `)
+  let assign_typename: (Js.Json.t, string) => Js.Json.t = (
+    %raw(` (obj, typename) => { obj.__typename = typename; return obj } `): (
+      Js.Json.t,
+      string,
+    ) => Js.Json.t
+  )
 }
 module DogFragment: {
   @@ocaml.warning("-32-30")

--- a/snapshot_tests/operations/expected/records/generate/fragmentWithdifferentReturnType.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/fragmentWithdifferentReturnType.res.txt
@@ -41,59 +41,55 @@ nullableOfNullable
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment: [#ListFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/records/generate/fragmentvariableinput.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/fragmentvariableinput.res.txt
@@ -35,54 +35,50 @@ id
 
 }
 "
-  let parse = (
-    (value): t => {
-      reposts: {
-        let value = (value: Raw.t).reposts
-        Js.Array2.map(value, value =>
-          switch Js.toOption(value) {
-          | Some(value) =>
-            Some(
-              (
-                {
-                  id: {
-                    let value = (value: Raw.t_reposts).id
-                    value
-                  },
-                }: t_reposts
-              ),
-            )
-          | None => None
-          }
-        )
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let reposts = {
-        let value = (value: t).reposts
-        Js.Array2.map(value, value =>
-          switch value {
-          | Some(value) =>
-            Js.Nullable.return(
-              (
-                {
-                  let id = {
-                    let value = (value: t_reposts).id
-                    value
-                  }
-                  {id: id}
-                }: Raw.t_reposts
-              ),
-            )
-          | None => Js.Nullable.null
-          }
-        )
-      }
-      {reposts: reposts}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    reposts: {
+      let value = (value: Raw.t).reposts
+      Js.Array2.map(value, value =>
+        switch Js.toOption(value) {
+        | Some(value) =>
+          Some(
+            (
+              {
+                id: {
+                  let value = (value: Raw.t_reposts).id
+                  value
+                },
+              }: t_reposts
+            ),
+          )
+        | None => None
+        }
+      )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let reposts = {
+      let value = (value: t).reposts
+      Js.Array2.map(value, value =>
+        switch value {
+        | Some(value) =>
+          Js.Nullable.return(
+            (
+              {
+                let id = {
+                  let value = (value: t_reposts).id
+                  value
+                }
+                {id: id}
+              }: Raw.t_reposts
+            ),
+          )
+        | None => Js.Nullable.null
+        }
+      )
+    }
+    {reposts: reposts}
+  }
   let verifyArgsAndParse = (
     ~name as _name: [#NonNull_String],
     ~fragmentName as _test: [#test],

--- a/snapshot_tests/operations/expected/records/generate/hasuraRepro.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/hasuraRepro.res.txt
@@ -28,23 +28,19 @@ function back to the original JSON-compatible data ")
 name  
 }
 "
-  let parse = (
-    (value): t => {
-      name: {
-        let value = (value: Raw.t).name
-        value
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let name = {
-        let value = (value: t).name
-        value
-      }
-      {name: name}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    name: {
+      let value = (value: Raw.t).name
+      value
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let name = {
+      let value = (value: t).name
+      value
+    }
+    {name: name}
+  }
   let verifyArgsAndParse = (~fragmentName as _Dog: [#Dog], value: Raw.t) => parse(value)
   let verifyName = x => switch x {
   | #Dog => ()

--- a/snapshot_tests/operations/expected/records/generate/hasuraRepro.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/hasuraRepro.res.txt
@@ -118,22 +118,24 @@ hasuraRepro(orderBy: [{id: desc}], block: {number: $blockNumber, type: $type})  
     }
     {hasuraRepro: hasuraRepro}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    blockNumber: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).blockNumber),
-    type_: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).type_),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      blockNumber: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).blockNumber),
+      type_: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).type_),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~blockNumber=?, ~type_=?, ()): t_variables => {blockNumber, type_}
   let makeDefaultVariables = () => makeVariables()
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"

--- a/snapshot_tests/operations/expected/records/generate/listsArgs.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/listsArgs.res.txt
@@ -68,51 +68,53 @@ listsInput(arg: {nullableOfNullable: $nullableOfNullable, nullableOfNonNullable:
     }
     {listsInput: listsInput}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    nullableOfNullable: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      nullableOfNullable: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables).nullableOfNullable),
+      nullableOfNonNullable: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => Js.Array2.map(a, b => (a => a)(b)))(b))
+          }
+      )((inp: t_variables).nullableOfNonNullable),
+      nonNullableOfNullable: (
+        a =>
+          Js.Array2.map(a, b =>
             (
               a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
+                switch a {
+                | None => Js.Nullable.undefined
+                | Some(b) => Js.Nullable.return((a => a)(b))
+                }
+            )(b)
           )
-        }
-    )((inp: t_variables).nullableOfNullable),
-    nullableOfNonNullable: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => Js.Array2.map(a, b => (a => a)(b)))(b))
-        }
-    )((inp: t_variables).nullableOfNonNullable),
-    nonNullableOfNullable: (
-      a =>
-        Js.Array2.map(a, b =>
-          (
-            a =>
-              switch a {
-              | None => Js.Nullable.undefined
-              | Some(b) => Js.Nullable.return((a => a)(b))
-              }
-          )(b)
-        )
-    )((inp: t_variables).nonNullableOfNullable),
-    nonNullableOfNonNullable: (a => Js.Array2.map(a, b => (a => a)(b)))(
-      (inp: t_variables).nonNullableOfNonNullable,
-    ),
-  }
+      )((inp: t_variables).nonNullableOfNullable),
+      nonNullableOfNonNullable: (a => Js.Array2.map(a, b => (a => a)(b)))(
+        (inp: t_variables).nonNullableOfNonNullable,
+      ),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (
     ~nullableOfNullable=?,
     ~nullableOfNonNullable=?,

--- a/snapshot_tests/operations/expected/records/generate/listsInput.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/listsInput.res.txt
@@ -74,54 +74,58 @@ listsInput(arg: $arg)
     }
     {listsInput: listsInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectListsInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectListsInput: t_variables_ListsInput => Raw.t_variables_ListsInput = inp => {
-    nullableOfNullable: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectListsInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectListsInput: t_variables_ListsInput => Raw.t_variables_ListsInput = (
+    inp => {
+      nullableOfNullable: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_ListsInput).nullableOfNullable),
+      nullableOfNonNullable: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => Js.Array2.map(a, b => (a => a)(b)))(b))
+          }
+      )((inp: t_variables_ListsInput).nullableOfNonNullable),
+      nonNullableOfNullable: (
+        a =>
+          Js.Array2.map(a, b =>
             (
               a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
+                switch a {
+                | None => Js.Nullable.undefined
+                | Some(b) => Js.Nullable.return((a => a)(b))
+                }
+            )(b)
           )
-        }
-    )((inp: t_variables_ListsInput).nullableOfNullable),
-    nullableOfNonNullable: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => Js.Array2.map(a, b => (a => a)(b)))(b))
-        }
-    )((inp: t_variables_ListsInput).nullableOfNonNullable),
-    nonNullableOfNullable: (
-      a =>
-        Js.Array2.map(a, b =>
-          (
-            a =>
-              switch a {
-              | None => Js.Nullable.undefined
-              | Some(b) => Js.Nullable.return((a => a)(b))
-              }
-          )(b)
-        )
-    )((inp: t_variables_ListsInput).nonNullableOfNullable),
-    nonNullableOfNonNullable: (a => Js.Array2.map(a, b => (a => a)(b)))(
-      (inp: t_variables_ListsInput).nonNullableOfNonNullable,
-    ),
-  }
+      )((inp: t_variables_ListsInput).nonNullableOfNullable),
+      nonNullableOfNonNullable: (a => Js.Array2.map(a, b => (a => a)(b)))(
+        (inp: t_variables_ListsInput).nonNullableOfNonNullable,
+      ),
+    }: t_variables_ListsInput => Raw.t_variables_ListsInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectListsInput = (
     ~nullableOfNullable=?,

--- a/snapshot_tests/operations/expected/records/generate/module_type.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/module_type.res.txt
@@ -263,8 +263,10 @@ and VariousScalars: {
   let parse = (nestedObject: MyQueryRecursive.t_nestedObject) => {
     otherInner: nestedObject.inner,
   }
-  let serialize: t => MyQueryRecursive.t_nestedObject = t => {
-    inner: t.otherInner,
-  }
+  let serialize: t => MyQueryRecursive.t_nestedObject = (
+    t => {
+      inner: t.otherInner,
+    }: t => MyQueryRecursive.t_nestedObject
+  )
 }
 

--- a/snapshot_tests/operations/expected/records/generate/mutationWithArgs.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/mutationWithArgs.res.txt
@@ -42,9 +42,9 @@ optionalInputArgs(required: $required, anotherRequired: "val")
     }
     {optionalInputArgs: optionalInputArgs}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    required: (a => a)((inp: t_variables).required),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {required: (a => a)((inp: t_variables).required)}: t_variables => Raw.t_variables
+  )
   let makeVariables = (~required, ()): t_variables => {required: required}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/records/generate/mutationWithArgsAndNoRecords.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/mutationWithArgsAndNoRecords.res.txt
@@ -42,9 +42,9 @@ optionalInputArgs(required: $required, anotherRequired: "val")
     }
     {optionalInputArgs: optionalInputArgs}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    required: (a => a)((inp: t_variables).required),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {required: (a => a)((inp: t_variables).required)}: t_variables => Raw.t_variables
+  )
   let makeVariables = (~required, ()): t_variables => {required: required}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/records/generate/nonrecursiveInput.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/nonrecursiveInput.res.txt
@@ -90,95 +90,101 @@ nonrecursiveInput(arg: $arg)
     }
     {nonrecursiveInput: nonrecursiveInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = inp => {
-    nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
-    nullableArray: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).nullableArray),
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).field),
-    enum: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                switch a {
-                | #FIRST => "FIRST"
-                | #SECOND => "SECOND"
-                | #THIRD => "THIRD"
-                }
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).enum),
-    embeddedInput: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) =>
-                        Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).embeddedInput),
-    custom: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).custom),
-  }
-  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = inp => {
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_EmbeddedInput).field),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = (
+    inp => {
+      nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
+      nullableArray: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).nullableArray),
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).field),
+      enum: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  switch a {
+                  | #FIRST => "FIRST"
+                  | #SECOND => "SECOND"
+                  | #THIRD => "THIRD"
+                  }
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).enum),
+      embeddedInput: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) =>
+                          Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).embeddedInput),
+      custom: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).custom),
+    }: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput
+  )
+  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = (
+    inp => {
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_EmbeddedInput).field),
+    }: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectNonrecursiveInput = (
     ~nonNullableField,
@@ -315,96 +321,102 @@ more: scalarsInput(arg: $arg2)
     }
     {scalarsInput, more}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
-    arg2: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg2),
-  }
-  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = inp => {
-    nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
-    nullableArray: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).nullableArray),
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).field),
-    enum: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                switch a {
-                | #FIRST => "FIRST"
-                | #SECOND => "SECOND"
-                | #THIRD => "THIRD"
-                }
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).enum),
-    embeddedInput: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) =>
-                        Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).embeddedInput),
-    custom: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).custom),
-  }
-  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = inp => {
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_EmbeddedInput).field),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
+      arg2: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg2),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = (
+    inp => {
+      nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
+      nullableArray: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).nullableArray),
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).field),
+      enum: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  switch a {
+                  | #FIRST => "FIRST"
+                  | #SECOND => "SECOND"
+                  | #THIRD => "THIRD"
+                  }
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).enum),
+      embeddedInput: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) =>
+                          Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).embeddedInput),
+      custom: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).custom),
+    }: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput
+  )
+  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = (
+    inp => {
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_EmbeddedInput).field),
+    }: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput
+  )
   let makeVariables = (~arg, ~arg2, ()): t_variables => {arg, arg2}
   and makeInputObjectNonrecursiveInput = (
     ~nonNullableField,

--- a/snapshot_tests/operations/expected/records/generate/pokedexScalars.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/pokedexScalars.res.txt
@@ -101,22 +101,24 @@ name
     }
     {pokemon: pokemon}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    id: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).id),
-    name: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).name),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      id: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).id),
+      name: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).name),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~id=?, ~name=?, ()): t_variables => {id, name}
   let makeDefaultVariables = () => makeVariables()
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
@@ -226,22 +228,24 @@ name
     }
     {pokemon: pokemon}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    id: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).id),
-    name: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).name),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      id: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).id),
+      name: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).name),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~id=?, ~name=?, ()): t_variables => {id, name}
   let makeDefaultVariables = () => makeVariables()
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"

--- a/snapshot_tests/operations/expected/records/generate/record.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/record.res.txt
@@ -333,31 +333,27 @@ string
 int  
 }
 "
-    let parse = (
-      (value): t => {
-        string: {
-          let value = (value: Raw.t).string
-          value
-        },
-        int: {
-          let value = (value: Raw.t).int
-          value
-        },
-      }: Raw.t => t
-    )
-    let serialize = (
-      (value): Raw.t => {
-        let int = {
-          let value = (value: t).int
-          value
-        }
-        and string = {
-          let value = (value: t).string
-          value
-        }
-        {string, int}
-      }: t => Raw.t
-    )
+    let parse = (value): t => {
+      string: {
+        let value = (value: Raw.t).string
+        value
+      },
+      int: {
+        let value = (value: Raw.t).int
+        value
+      },
+    }
+    let serialize = (value): Raw.t => {
+      let int = {
+        let value = (value: t).int
+        value
+      }
+      and string = {
+        let value = (value: t).string
+        value
+      }
+      {string, int}
+    }
     let verifyArgsAndParse = (~fragmentName as _Fragment: [#Fragment], value: Raw.t) => parse(value)
     let verifyName = x => switch x {
     | #Fragment => ()
@@ -600,39 +596,35 @@ name
 barkVolume  
 }
 "
-    let parse = (
-      (value): t => {
-        __typename: {
-          let value = (value: Raw.t).__typename
-          value
-        },
-        name: {
-          let value = (value: Raw.t).name
-          value
-        },
-        barkVolume: {
-          let value = (value: Raw.t).barkVolume
-          value
-        },
-      }: Raw.t => t
-    )
-    let serialize = (
-      (value): Raw.t => {
-        let barkVolume = {
-          let value = (value: t).barkVolume
-          value
-        }
-        and name = {
-          let value = (value: t).name
-          value
-        }
-        and __typename = {
-          let value = (value: t).__typename
-          value
-        }
-        {__typename, name, barkVolume}
-      }: t => Raw.t
-    )
+    let parse = (value): t => {
+      __typename: {
+        let value = (value: Raw.t).__typename
+        value
+      },
+      name: {
+        let value = (value: Raw.t).name
+        value
+      },
+      barkVolume: {
+        let value = (value: Raw.t).barkVolume
+        value
+      },
+    }
+    let serialize = (value): Raw.t => {
+      let barkVolume = {
+        let value = (value: t).barkVolume
+        value
+      }
+      and name = {
+        let value = (value: t).name
+        value
+      }
+      and __typename = {
+        let value = (value: t).__typename
+        value
+      }
+      {__typename, name, barkVolume}
+    }
     let verifyArgsAndParse = (~fragmentName as _DogFragment: [#DogFragment], value: Raw.t) =>
       parse(value)
     let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/records/generate/recursiveInput.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/recursiveInput.res.txt
@@ -69,42 +69,46 @@ recursiveInput(arg: $arg)
     }
     {recursiveInput: recursiveInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectRecursiveInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectRecursiveInput: t_variables_RecursiveInput => Raw.t_variables_RecursiveInput = inp => {
-    otherField: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_RecursiveInput).otherField),
-    inner: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => serializeInputObjectRecursiveInput(a))(b))
-        }
-    )((inp: t_variables_RecursiveInput).inner),
-    enum: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                switch a {
-                | #FIRST => "FIRST"
-                | #SECOND => "SECOND"
-                | #THIRD => "THIRD"
-                }
-            )(b),
-          )
-        }
-    )((inp: t_variables_RecursiveInput).enum),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectRecursiveInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectRecursiveInput: t_variables_RecursiveInput => Raw.t_variables_RecursiveInput = (
+    inp => {
+      otherField: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_RecursiveInput).otherField),
+      inner: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => serializeInputObjectRecursiveInput(a))(b))
+          }
+      )((inp: t_variables_RecursiveInput).inner),
+      enum: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  switch a {
+                  | #FIRST => "FIRST"
+                  | #SECOND => "SECOND"
+                  | #THIRD => "THIRD"
+                  }
+              )(b),
+            )
+          }
+      )((inp: t_variables_RecursiveInput).enum),
+    }: t_variables_RecursiveInput => Raw.t_variables_RecursiveInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectRecursiveInput = (
     ~otherField=?,
@@ -200,37 +204,45 @@ recursiveRepro(input: $input)
     }
     {recursiveRepro: recursiveRepro}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    input: (a => serializeInputObjectproblem_input(a))((inp: t_variables).input),
-  }
-  and serializeInputObjectproblem_input: t_variables_problem_input => Raw.t_variables_problem_input = inp => {
-    the_problem: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => serializeInputObjectthis_will_be_duplicated(a))(b))
-        }
-    )((inp: t_variables_problem_input).the_problem),
-    b: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => serializeInputObjectnested_type(a))(b))
-        }
-    )((inp: t_variables_problem_input).b),
-  }
-  and serializeInputObjectthis_will_be_duplicated: t_variables_this_will_be_duplicated => Raw.t_variables_this_will_be_duplicated = inp => {
-    id: (a => a)((inp: t_variables_this_will_be_duplicated).id),
-  }
-  and serializeInputObjectnested_type: t_variables_nested_type => Raw.t_variables_nested_type = inp => {
-    the_problem: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => serializeInputObjectthis_will_be_duplicated(a))(b))
-        }
-    )((inp: t_variables_nested_type).the_problem),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      input: (a => serializeInputObjectproblem_input(a))((inp: t_variables).input),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectproblem_input: t_variables_problem_input => Raw.t_variables_problem_input = (
+    inp => {
+      the_problem: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => serializeInputObjectthis_will_be_duplicated(a))(b))
+          }
+      )((inp: t_variables_problem_input).the_problem),
+      b: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => serializeInputObjectnested_type(a))(b))
+          }
+      )((inp: t_variables_problem_input).b),
+    }: t_variables_problem_input => Raw.t_variables_problem_input
+  )
+  and serializeInputObjectthis_will_be_duplicated: t_variables_this_will_be_duplicated => Raw.t_variables_this_will_be_duplicated = (
+    inp => {
+      id: (a => a)((inp: t_variables_this_will_be_duplicated).id),
+    }: t_variables_this_will_be_duplicated => Raw.t_variables_this_will_be_duplicated
+  )
+  and serializeInputObjectnested_type: t_variables_nested_type => Raw.t_variables_nested_type = (
+    inp => {
+      the_problem: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => serializeInputObjectthis_will_be_duplicated(a))(b))
+          }
+      )((inp: t_variables_nested_type).the_problem),
+    }: t_variables_nested_type => Raw.t_variables_nested_type
+  )
   let makeVariables = (~input, ()): t_variables => {input: input}
   and makeInputObjectproblem_input = (~the_problem=?, ~b=?, ()): t_variables_problem_input => {
     the_problem,

--- a/snapshot_tests/operations/expected/records/generate/scalarsArgs.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/scalarsArgs.res.txt
@@ -98,48 +98,50 @@ scalarsInput(arg: {nullableString: $nullableString, string: $string, nullableInt
     }
     {scalarsInput: scalarsInput}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    nullableString: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableString),
-    string: (a => a)((inp: t_variables).string),
-    nullableInt: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableInt),
-    int: (a => a)((inp: t_variables).int),
-    nullableFloat: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableFloat),
-    float: (a => a)((inp: t_variables).float),
-    nullableBoolean: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableBoolean),
-    boolean: (a => a)((inp: t_variables).boolean),
-    nullableID: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableID),
-    id: (a => a)((inp: t_variables).id),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      nullableString: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableString),
+      string: (a => a)((inp: t_variables).string),
+      nullableInt: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableInt),
+      int: (a => a)((inp: t_variables).int),
+      nullableFloat: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableFloat),
+      float: (a => a)((inp: t_variables).float),
+      nullableBoolean: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableBoolean),
+      boolean: (a => a)((inp: t_variables).boolean),
+      nullableID: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableID),
+      id: (a => a)((inp: t_variables).id),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (
     ~nullableString=?,
     ~string,

--- a/snapshot_tests/operations/expected/records/generate/scalarsInput.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/scalarsInput.res.txt
@@ -104,51 +104,55 @@ scalarsInput(arg: $arg)
     }
     {scalarsInput: scalarsInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectVariousScalarsInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectVariousScalarsInput: t_variables_VariousScalarsInput => Raw.t_variables_VariousScalarsInput = inp => {
-    nullableString: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableString),
-    string: (a => a)((inp: t_variables_VariousScalarsInput).string),
-    nullableInt: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableInt),
-    int: (a => a)((inp: t_variables_VariousScalarsInput).int),
-    nullableFloat: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableFloat),
-    float: (a => a)((inp: t_variables_VariousScalarsInput).float),
-    nullableBoolean: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableBoolean),
-    boolean: (a => a)((inp: t_variables_VariousScalarsInput).boolean),
-    nullableID: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableID),
-    id: (a => a)((inp: t_variables_VariousScalarsInput).id),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectVariousScalarsInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectVariousScalarsInput: t_variables_VariousScalarsInput => Raw.t_variables_VariousScalarsInput = (
+    inp => {
+      nullableString: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableString),
+      string: (a => a)((inp: t_variables_VariousScalarsInput).string),
+      nullableInt: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableInt),
+      int: (a => a)((inp: t_variables_VariousScalarsInput).int),
+      nullableFloat: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableFloat),
+      float: (a => a)((inp: t_variables_VariousScalarsInput).float),
+      nullableBoolean: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableBoolean),
+      boolean: (a => a)((inp: t_variables_VariousScalarsInput).boolean),
+      nullableID: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableID),
+      id: (a => a)((inp: t_variables_VariousScalarsInput).id),
+    }: t_variables_VariousScalarsInput => Raw.t_variables_VariousScalarsInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectVariousScalarsInput = (
     ~nullableString=?,

--- a/snapshot_tests/operations/expected/records/generate/skipDirectives.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/skipDirectives.res.txt
@@ -164,9 +164,9 @@ string @include(if: $var)
     }
     {v1, v2}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    var: (a => a)((inp: t_variables).var),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {var: (a => a)((inp: t_variables).var)}: t_variables => Raw.t_variables
+  )
   let makeVariables = (~var, ()): t_variables => {var: var}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/records/generate/tagged_template.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/tagged_template.res.txt
@@ -1545,59 +1545,55 @@ nullableOfNonNullable
     ],
     [],
   )
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment: [#ListFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -1847,59 +1843,55 @@ nullableOfNonNullable
     ],
     [],
   )
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment8: [#ListFragment8], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/records/generate/union.res.txt
+++ b/snapshot_tests/operations/expected/records/generate/union.res.txt
@@ -541,31 +541,27 @@ name
 __typename  
 }
 "
-    let parse = (
-      (value): named => {
-        name: {
-          let value = (value: Raw.t).name
-          value
-        },
-        __typename: {
-          let value = (value: Raw.t).__typename
-          value
-        },
-      }: Raw.t => named
-    )
-    let serialize = (
-      (value): Raw.t => {
-        let __typename = {
-          let value = (value: named).__typename
-          value
-        }
-        and name = {
-          let value = (value: named).name
-          value
-        }
-        {name, __typename}
-      }: named => Raw.t
-    )
+    let parse = (value): named => {
+      name: {
+        let value = (value: Raw.t).name
+        value
+      },
+      __typename: {
+        let value = (value: Raw.t).__typename
+        value
+      },
+    }
+    let serialize = (value): Raw.t => {
+      let __typename = {
+        let value = (value: named).__typename
+        value
+      }
+      and name = {
+        let value = (value: named).name
+        value
+      }
+      {name, __typename}
+    }
     let verifyArgsAndParse = (~fragmentName as _DogFields: [#DogFields], value: Raw.t) =>
       parse(value)
     let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/template/generate/argNamedQuery.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/argNamedQuery.res.txt
@@ -42,9 +42,9 @@ argNamedQuery(query: $query)
     }
     {argNamedQuery: argNamedQuery}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    query: (a => a)((inp: t_variables).query),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {query: (a => a)((inp: t_variables).query)}: t_variables => Raw.t_variables
+  )
   let makeVariables = (~query, ()): t_variables => {query: query}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"
@@ -95,9 +95,9 @@ argNamedQuery(query: $query)
       }
       {argNamedQuery: argNamedQuery}
     }
-    let serializeVariables: t_variables => Raw.t_variables = inp => {
-      query: (a => a)((inp: t_variables).query),
-    }
+    let serializeVariables: t_variables => Raw.t_variables = (
+      inp => {query: (a => a)((inp: t_variables).query)}: t_variables => Raw.t_variables
+    )
     let makeVariables = (~query, ()): t_variables => {query: query}
     external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
     external toJson: Raw.t => Js.Json.t = "%identity"
@@ -147,9 +147,9 @@ argNamedQuery(query: $query)
       }
       {argNamedQuery: argNamedQuery}
     }
-    let serializeVariables: t_variables => Raw.t_variables = inp => {
-      query: (a => a)((inp: t_variables).query),
-    }
+    let serializeVariables: t_variables => Raw.t_variables = (
+      inp => {query: (a => a)((inp: t_variables).query)}: t_variables => Raw.t_variables
+    )
     let makeVariables = (~query, ()): t_variables => {query: query}
     external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
     external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/template/generate/comment.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/comment.res.txt
@@ -90,95 +90,101 @@ nonrecursiveInput(arg: $arg)
     }
     {nonrecursiveInput: nonrecursiveInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = inp => {
-    nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
-    nullableArray: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).nullableArray),
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).field),
-    enum: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                switch a {
-                | #FIRST => "FIRST"
-                | #SECOND => "SECOND"
-                | #THIRD => "THIRD"
-                }
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).enum),
-    embeddedInput: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) =>
-                        Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).embeddedInput),
-    custom: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).custom),
-  }
-  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = inp => {
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_EmbeddedInput).field),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = (
+    inp => {
+      nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
+      nullableArray: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).nullableArray),
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).field),
+      enum: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  switch a {
+                  | #FIRST => "FIRST"
+                  | #SECOND => "SECOND"
+                  | #THIRD => "THIRD"
+                  }
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).enum),
+      embeddedInput: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) =>
+                          Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).embeddedInput),
+      custom: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).custom),
+    }: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput
+  )
+  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = (
+    inp => {
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_EmbeddedInput).field),
+    }: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectNonrecursiveInput = (
     ~nonNullableField,

--- a/snapshot_tests/operations/expected/template/generate/customScalars.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/customScalars.res.txt
@@ -88,16 +88,18 @@ nonNullable
     }
     {customScalarField: customScalarField}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    opt: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).opt),
-    req: (a => a)((inp: t_variables).req),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      opt: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).opt),
+      req: (a => a)((inp: t_variables).req),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~opt=?, ~req, ()): t_variables => {opt, req}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/template/generate/customTypes.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/customTypes.res.txt
@@ -25,21 +25,25 @@ module NullableString = {
     | Red
     | Green
     | Blue
-  let parse: option<string> => t = color =>
-    switch color {
-    | Some("green") => Green
-    | Some("blue") => Blue
-    | Some("red") => Red
-    | Some(_)
-    | None =>
-      Red
-    }
-  let serialize: t => option<string> = color =>
-    switch color {
-    | Red => Some("red")
-    | Green => Some("green")
-    | Blue => Some("blue")
-    }
+  let parse: option<string> => t = (
+    color =>
+      switch color {
+      | Some("green") => Green
+      | Some("blue") => Blue
+      | Some("red") => Red
+      | Some(_)
+      | None =>
+        Red
+      }: option<string> => t
+  )
+  let serialize: t => option<string> = (
+    color =>
+      switch color {
+      | Red => Some("red")
+      | Green => Some("green")
+      | Blue => Some("blue")
+      }: t => option<string>
+  )
 }
 
 module DateTime = {

--- a/snapshot_tests/operations/expected/template/generate/enumInput.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/enumInput.res.txt
@@ -42,16 +42,18 @@ enumInput(arg: $arg)
     }
     {enumInput: enumInput}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (
-      a =>
-        switch a {
-        | #FIRST => "FIRST"
-        | #SECOND => "SECOND"
-        | #THIRD => "THIRD"
-        }
-    )((inp: t_variables).arg),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (
+        a =>
+          switch a {
+          | #FIRST => "FIRST"
+          | #SECOND => "SECOND"
+          | #THIRD => "THIRD"
+          }
+      )((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/template/generate/ewert_reproduction.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/ewert_reproduction.res.txt
@@ -49,60 +49,56 @@ lastname
 
 }
 "
-  let parse = (
-    (value): t => {
-      user: {
-        let value = (value: Raw.t).user
-        (
-          {
-            id: {
-              let value = (value: Raw.t_user).id
-              value
-            },
-            firstname: {
-              let value = (value: Raw.t_user).firstname
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            },
-            lastname: {
-              let value = (value: Raw.t_user).lastname
-              value
-            },
-          }: t_user
-        )
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let user = {
-        let value = (value: t).user
-        (
-          {
-            let lastname = {
-              let value = (value: t_user).lastname
-              value
+  let parse = (value): t => {
+    user: {
+      let value = (value: Raw.t).user
+      (
+        {
+          id: {
+            let value = (value: Raw.t_user).id
+            value
+          },
+          firstname: {
+            let value = (value: Raw.t_user).firstname
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
             }
-            and firstname = {
-              let value = (value: t_user).firstname
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
+          },
+          lastname: {
+            let value = (value: Raw.t_user).lastname
+            value
+          },
+        }: t_user
+      )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let user = {
+      let value = (value: t).user
+      (
+        {
+          let lastname = {
+            let value = (value: t_user).lastname
+            value
+          }
+          and firstname = {
+            let value = (value: t_user).firstname
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
             }
-            and id = {
-              let value = (value: t_user).id
-              value
-            }
-            {id, firstname, lastname}
-          }: Raw.t_user
-        )
-      }
-      {user: user}
-    }: t => Raw.t
-  )
+          }
+          and id = {
+            let value = (value: t_user).id
+            value
+          }
+          {id, firstname, lastname}
+        }: Raw.t_user
+      )
+    }
+    {user: user}
+  }
   let verifyArgsAndParse = (
     ~userId as _userId: [#NonNull_String],
     ~fragmentName as _UserData: [#UserData],

--- a/snapshot_tests/operations/expected/template/generate/fragmentDefinition.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/fragmentDefinition.res.txt
@@ -709,15 +709,17 @@ l5: lists  {
     }
     {l1, l2, l3, l4, l5}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg1: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).arg1),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg1: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).arg1),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~arg1=?, ()): t_variables => {arg1: arg1}
   let makeDefaultVariables = () => makeVariables()
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"

--- a/snapshot_tests/operations/expected/template/generate/fragmentDefinition.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/fragmentDefinition.res.txt
@@ -45,59 +45,55 @@ nullableOfNullable
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment: [#ListFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -136,29 +132,25 @@ function back to the original JSON-compatible data ")
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNonNullable: nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNonNullable: nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _Another: [#Another], value: Raw.t) => parse(value)
   let verifyName = x => switch x {
   | #Another => ()
@@ -196,45 +188,41 @@ function back to the original JSON-compatible data ")
 listWithArg(arg1: $arg1)  
 }
 "
-  let parse = (
-    (value): t => {
-      listWithArg: {
-        let value = (value: Raw.t).listWithArg
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let listWithArg = {
-        let value = (value: t).listWithArg
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    listWithArg: {
+      let value = (value: Raw.t).listWithArg
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      {listWithArg: listWithArg}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let listWithArg = {
+      let value = (value: t).listWithArg
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {listWithArg: listWithArg}
+  }
   let verifyArgsAndParse = (
     ~arg1 as _arg1: [#String],
     ~fragmentName as _FragmentWithArgs: [#FragmentWithArgs],
@@ -266,59 +254,55 @@ nullableOfNullable
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (
     ~fragmentName as _InlineListFragment: [#InlineListFragment],
     value: Raw.t,
@@ -349,59 +333,55 @@ nullableOfNullable
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (
     ~fragmentName as _InlineListFragment: [#InlineListFragment],
     value: Raw.t,

--- a/snapshot_tests/operations/expected/template/generate/fragmentInFragment.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/fragmentInFragment.res.txt
@@ -32,45 +32,41 @@ function back to the original JSON-compatible data ")
 nullableOfNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      {nullableOfNullable: nullableOfNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable: nullableOfNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment: [#ListFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -119,59 +115,55 @@ nullableOfNullable
 ",
     ListFragment.query,
   )
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "nullableOfNullable"))
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      listFragment: {
-        let value = (Obj.magic(value): ListFragment.Raw.t)
-
-        ListFragment.verifyArgsAndParse(~fragmentName=#ListFragment, value)
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t =>
-      Obj.magic(
-        Js.Array2.reduce(
-          [(Obj.magic(ListFragment.serialize((value: t).listFragment)): Js.Json.t)],
-          Graphql_ppx_runtime.deepMerge,
-          (
-            Obj.magic({
-              let nullableOfNullable = {
-                let value = (value: t).nullableOfNullable
-                switch value {
-                | Some(value) =>
-                  Js.Nullable.return(
-                    Js.Array2.map(value, value =>
-                      switch value {
-                      | Some(value) => Js.Nullable.return(value)
-                      | None => Js.Nullable.null
-                      }
-                    ),
-                  )
-                | None => Js.Nullable.null
-                }
-              }
-              {"nullableOfNullable": nullableOfNullable}
-            }): Js.Json.t
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "nullableOfNullable"))
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
           ),
+        )
+      | None => None
+      }
+    },
+    listFragment: {
+      let value = (Obj.magic(value): ListFragment.Raw.t)
+
+      ListFragment.verifyArgsAndParse(~fragmentName=#ListFragment, value)
+    },
+  }
+  let serialize = (value): Raw.t =>
+    Obj.magic(
+      Js.Array2.reduce(
+        [(Obj.magic(ListFragment.serialize((value: t).listFragment)): Js.Json.t)],
+        Graphql_ppx_runtime.deepMerge,
+        (
+          Obj.magic({
+            let nullableOfNullable = {
+              let value = (value: t).nullableOfNullable
+              switch value {
+              | Some(value) =>
+                Js.Nullable.return(
+                  Js.Array2.map(value, value =>
+                    switch value {
+                    | Some(value) => Js.Nullable.return(value)
+                    | None => Js.Nullable.null
+                    }
+                  ),
+                )
+              | None => Js.Nullable.null
+              }
+            }
+            {"nullableOfNullable": nullableOfNullable}
+          }): Js.Json.t
         ),
-      ): t => Raw.t
-  )
+      ),
+    )
   let verifyArgsAndParse = (~fragmentName as _Another: [#Another], value: Raw.t) => parse(value)
   let verifyName = x => switch x {
   | #Another => ()

--- a/snapshot_tests/operations/expected/template/generate/fragmentOnInterface.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/fragmentOnInterface.res.txt
@@ -45,23 +45,19 @@ __typename
 id  
 }
 "
-  let parse = (
-    (value): t => {
-      id: {
-        let value = (value: Raw.t).id
-        value
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let id = {
-        let value = (value: t).id
-        value
-      }
-      {id: id}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    id: {
+      let value = (value: Raw.t).id
+      value
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let id = {
+      let value = (value: t).id
+      value
+    }
+    {id: id}
+  }
   let verifyArgsAndParse = (
     ~fragmentName as _InterfaceFragment: [#InterfaceFragment],
     value: Raw.t,
@@ -119,37 +115,33 @@ id
 ",
     InterfaceFragment.query,
   )
-  let parse = (
-    (value): t => {
-      id: {
-        let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "id"))
-        value
-      },
-      interfaceFragment: {
-        let value = (Obj.magic(value): InterfaceFragment.Raw.t)
+  let parse = (value): t => {
+    id: {
+      let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "id"))
+      value
+    },
+    interfaceFragment: {
+      let value = (Obj.magic(value): InterfaceFragment.Raw.t)
 
-        InterfaceFragment.verifyArgsAndParse(~fragmentName=#InterfaceFragment, value)
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t =>
-      Obj.magic(
-        Js.Array2.reduce(
-          [(Obj.magic(InterfaceFragment.serialize((value: t).interfaceFragment)): Js.Json.t)],
-          Graphql_ppx_runtime.deepMerge,
-          (
-            Obj.magic({
-              let id = {
-                let value = (value: t).id
-                value
-              }
-              {"id": id}
-            }): Js.Json.t
-          ),
+      InterfaceFragment.verifyArgsAndParse(~fragmentName=#InterfaceFragment, value)
+    },
+  }
+  let serialize = (value): Raw.t =>
+    Obj.magic(
+      Js.Array2.reduce(
+        [(Obj.magic(InterfaceFragment.serialize((value: t).interfaceFragment)): Js.Json.t)],
+        Graphql_ppx_runtime.deepMerge,
+        (
+          Obj.magic({
+            let id = {
+              let value = (value: t).id
+              value
+            }
+            {"id": id}
+          }): Js.Json.t
         ),
-      ): t => Raw.t
-  )
+      ),
+    )
   let verifyArgsAndParse = (~fragmentName as _AnotherFragment: [#AnotherFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -192,37 +184,33 @@ id
 ",
     InterfaceFragment.query,
   )
-  let parse = (
-    (value): t => {
-      id: {
-        let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "id"))
-        value
-      },
-      interfaceFragment: {
-        let value = (Obj.magic(value): InterfaceFragment.Raw.t)
+  let parse = (value): t => {
+    id: {
+      let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "id"))
+      value
+    },
+    interfaceFragment: {
+      let value = (Obj.magic(value): InterfaceFragment.Raw.t)
 
-        InterfaceFragment.verifyArgsAndParse(~fragmentName=#InterfaceFragment, value)
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t =>
-      Obj.magic(
-        Js.Array2.reduce(
-          [(Obj.magic(InterfaceFragment.serialize((value: t).interfaceFragment)): Js.Json.t)],
-          Graphql_ppx_runtime.deepMerge,
-          (
-            Obj.magic({
-              let id = {
-                let value = (value: t).id
-                value
-              }
-              {"id": id}
-            }): Js.Json.t
-          ),
+      InterfaceFragment.verifyArgsAndParse(~fragmentName=#InterfaceFragment, value)
+    },
+  }
+  let serialize = (value): Raw.t =>
+    Obj.magic(
+      Js.Array2.reduce(
+        [(Obj.magic(InterfaceFragment.serialize((value: t).interfaceFragment)): Js.Json.t)],
+        Graphql_ppx_runtime.deepMerge,
+        (
+          Obj.magic({
+            let id = {
+              let value = (value: t).id
+              value
+            }
+            {"id": id}
+          }): Js.Json.t
         ),
-      ): t => Raw.t
-  )
+      ),
+    )
   let verifyArgsAndParse = (~fragmentName as _AnonUser: [#AnonUser], value: Raw.t) => parse(value)
   let verifyName = x => switch x {
   | #AnonUser => ()

--- a/snapshot_tests/operations/expected/template/generate/fragmentUnion.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/fragmentUnion.res.txt
@@ -37,23 +37,19 @@ function back to the original JSON-compatible data ")
 name  
 }
 "
-  let parse = (
-    (value): t => {
-      name: {
-        let value = (value: Raw.t).name
-        value
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let name = {
-        let value = (value: t).name
-        value
-      }
-      {name: name}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    name: {
+      let value = (value: Raw.t).name
+      value
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let name = {
+      let value = (value: t).name
+      value
+    }
+    {name: name}
+  }
   let verifyArgsAndParse = (~fragmentName as _DogFragment: [#DogFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -92,23 +88,19 @@ function back to the original JSON-compatible data ")
 name  
 }
 "
-  let parse = (
-    (value): t => {
-      name: {
-        let value = (value: Raw.t).name
-        value
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let name = {
-        let value = (value: t).name
-        value
-      }
-      {name: name}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    name: {
+      let value = (value: Raw.t).name
+      value
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let name = {
+      let value = (value: t).name
+      value
+    }
+    {name: name}
+  }
   let verifyArgsAndParse = (~fragmentName as _HumanFragment: [#HumanFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/template/generate/fragmentUnion.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/fragmentUnion.res.txt
@@ -1,9 +1,11 @@
 module Graphql_ppx_runtime = {
   // mock
-  let assign_typename: (
-    Js.Json.t,
-    string,
-  ) => Js.Json.t = %raw(` (obj, typename) => { obj.__typename = typename; return obj } `)
+  let assign_typename: (Js.Json.t, string) => Js.Json.t = (
+    %raw(` (obj, typename) => { obj.__typename = typename; return obj } `): (
+      Js.Json.t,
+      string,
+    ) => Js.Json.t
+  )
 }
 module DogFragment: {
   @@ocaml.warning("-32-30")

--- a/snapshot_tests/operations/expected/template/generate/fragmentWithdifferentReturnType.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/fragmentWithdifferentReturnType.res.txt
@@ -41,59 +41,55 @@ nullableOfNullable
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment: [#ListFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/template/generate/fragmentvariableinput.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/fragmentvariableinput.res.txt
@@ -35,54 +35,50 @@ id
 
 }
 "
-  let parse = (
-    (value): t => {
-      reposts: {
-        let value = (value: Raw.t).reposts
-        Js.Array2.map(value, value =>
-          switch Js.toOption(value) {
-          | Some(value) =>
-            Some(
-              (
-                {
-                  id: {
-                    let value = (value: Raw.t_reposts).id
-                    value
-                  },
-                }: t_reposts
-              ),
-            )
-          | None => None
-          }
-        )
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let reposts = {
-        let value = (value: t).reposts
-        Js.Array2.map(value, value =>
-          switch value {
-          | Some(value) =>
-            Js.Nullable.return(
-              (
-                {
-                  let id = {
-                    let value = (value: t_reposts).id
-                    value
-                  }
-                  {id: id}
-                }: Raw.t_reposts
-              ),
-            )
-          | None => Js.Nullable.null
-          }
-        )
-      }
-      {reposts: reposts}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    reposts: {
+      let value = (value: Raw.t).reposts
+      Js.Array2.map(value, value =>
+        switch Js.toOption(value) {
+        | Some(value) =>
+          Some(
+            (
+              {
+                id: {
+                  let value = (value: Raw.t_reposts).id
+                  value
+                },
+              }: t_reposts
+            ),
+          )
+        | None => None
+        }
+      )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let reposts = {
+      let value = (value: t).reposts
+      Js.Array2.map(value, value =>
+        switch value {
+        | Some(value) =>
+          Js.Nullable.return(
+            (
+              {
+                let id = {
+                  let value = (value: t_reposts).id
+                  value
+                }
+                {id: id}
+              }: Raw.t_reposts
+            ),
+          )
+        | None => Js.Nullable.null
+        }
+      )
+    }
+    {reposts: reposts}
+  }
   let verifyArgsAndParse = (
     ~name as _name: [#NonNull_String],
     ~fragmentName as _test: [#test],

--- a/snapshot_tests/operations/expected/template/generate/hasuraRepro.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/hasuraRepro.res.txt
@@ -28,23 +28,19 @@ function back to the original JSON-compatible data ")
 name  
 }
 "
-  let parse = (
-    (value): t => {
-      name: {
-        let value = (value: Raw.t).name
-        value
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let name = {
-        let value = (value: t).name
-        value
-      }
-      {name: name}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    name: {
+      let value = (value: Raw.t).name
+      value
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let name = {
+      let value = (value: t).name
+      value
+    }
+    {name: name}
+  }
   let verifyArgsAndParse = (~fragmentName as _Dog: [#Dog], value: Raw.t) => parse(value)
   let verifyName = x => switch x {
   | #Dog => ()

--- a/snapshot_tests/operations/expected/template/generate/hasuraRepro.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/hasuraRepro.res.txt
@@ -118,22 +118,24 @@ hasuraRepro(orderBy: [{id: desc}], block: {number: $blockNumber, type: $type})  
     }
     {hasuraRepro: hasuraRepro}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    blockNumber: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).blockNumber),
-    type_: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).type_),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      blockNumber: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).blockNumber),
+      type_: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).type_),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~blockNumber=?, ~type_=?, ()): t_variables => {blockNumber, type_}
   let makeDefaultVariables = () => makeVariables()
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"

--- a/snapshot_tests/operations/expected/template/generate/listsArgs.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/listsArgs.res.txt
@@ -68,51 +68,53 @@ listsInput(arg: {nullableOfNullable: $nullableOfNullable, nullableOfNonNullable:
     }
     {listsInput: listsInput}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    nullableOfNullable: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      nullableOfNullable: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables).nullableOfNullable),
+      nullableOfNonNullable: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => Js.Array2.map(a, b => (a => a)(b)))(b))
+          }
+      )((inp: t_variables).nullableOfNonNullable),
+      nonNullableOfNullable: (
+        a =>
+          Js.Array2.map(a, b =>
             (
               a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
+                switch a {
+                | None => Js.Nullable.undefined
+                | Some(b) => Js.Nullable.return((a => a)(b))
+                }
+            )(b)
           )
-        }
-    )((inp: t_variables).nullableOfNullable),
-    nullableOfNonNullable: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => Js.Array2.map(a, b => (a => a)(b)))(b))
-        }
-    )((inp: t_variables).nullableOfNonNullable),
-    nonNullableOfNullable: (
-      a =>
-        Js.Array2.map(a, b =>
-          (
-            a =>
-              switch a {
-              | None => Js.Nullable.undefined
-              | Some(b) => Js.Nullable.return((a => a)(b))
-              }
-          )(b)
-        )
-    )((inp: t_variables).nonNullableOfNullable),
-    nonNullableOfNonNullable: (a => Js.Array2.map(a, b => (a => a)(b)))(
-      (inp: t_variables).nonNullableOfNonNullable,
-    ),
-  }
+      )((inp: t_variables).nonNullableOfNullable),
+      nonNullableOfNonNullable: (a => Js.Array2.map(a, b => (a => a)(b)))(
+        (inp: t_variables).nonNullableOfNonNullable,
+      ),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (
     ~nullableOfNullable=?,
     ~nullableOfNonNullable=?,

--- a/snapshot_tests/operations/expected/template/generate/listsInput.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/listsInput.res.txt
@@ -74,54 +74,58 @@ listsInput(arg: $arg)
     }
     {listsInput: listsInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectListsInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectListsInput: t_variables_ListsInput => Raw.t_variables_ListsInput = inp => {
-    nullableOfNullable: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectListsInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectListsInput: t_variables_ListsInput => Raw.t_variables_ListsInput = (
+    inp => {
+      nullableOfNullable: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_ListsInput).nullableOfNullable),
+      nullableOfNonNullable: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => Js.Array2.map(a, b => (a => a)(b)))(b))
+          }
+      )((inp: t_variables_ListsInput).nullableOfNonNullable),
+      nonNullableOfNullable: (
+        a =>
+          Js.Array2.map(a, b =>
             (
               a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
+                switch a {
+                | None => Js.Nullable.undefined
+                | Some(b) => Js.Nullable.return((a => a)(b))
+                }
+            )(b)
           )
-        }
-    )((inp: t_variables_ListsInput).nullableOfNullable),
-    nullableOfNonNullable: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => Js.Array2.map(a, b => (a => a)(b)))(b))
-        }
-    )((inp: t_variables_ListsInput).nullableOfNonNullable),
-    nonNullableOfNullable: (
-      a =>
-        Js.Array2.map(a, b =>
-          (
-            a =>
-              switch a {
-              | None => Js.Nullable.undefined
-              | Some(b) => Js.Nullable.return((a => a)(b))
-              }
-          )(b)
-        )
-    )((inp: t_variables_ListsInput).nonNullableOfNullable),
-    nonNullableOfNonNullable: (a => Js.Array2.map(a, b => (a => a)(b)))(
-      (inp: t_variables_ListsInput).nonNullableOfNonNullable,
-    ),
-  }
+      )((inp: t_variables_ListsInput).nonNullableOfNullable),
+      nonNullableOfNonNullable: (a => Js.Array2.map(a, b => (a => a)(b)))(
+        (inp: t_variables_ListsInput).nonNullableOfNonNullable,
+      ),
+    }: t_variables_ListsInput => Raw.t_variables_ListsInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectListsInput = (
     ~nullableOfNullable=?,

--- a/snapshot_tests/operations/expected/template/generate/module_type.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/module_type.res.txt
@@ -263,8 +263,10 @@ and VariousScalars: {
   let parse = (nestedObject: MyQueryRecursive.t_nestedObject) => {
     otherInner: nestedObject.inner,
   }
-  let serialize: t => MyQueryRecursive.t_nestedObject = t => {
-    inner: t.otherInner,
-  }
+  let serialize: t => MyQueryRecursive.t_nestedObject = (
+    t => {
+      inner: t.otherInner,
+    }: t => MyQueryRecursive.t_nestedObject
+  )
 }
 

--- a/snapshot_tests/operations/expected/template/generate/mutationWithArgs.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/mutationWithArgs.res.txt
@@ -42,9 +42,9 @@ optionalInputArgs(required: $required, anotherRequired: "val")
     }
     {optionalInputArgs: optionalInputArgs}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    required: (a => a)((inp: t_variables).required),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {required: (a => a)((inp: t_variables).required)}: t_variables => Raw.t_variables
+  )
   let makeVariables = (~required, ()): t_variables => {required: required}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/template/generate/mutationWithArgsAndNoRecords.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/mutationWithArgsAndNoRecords.res.txt
@@ -42,9 +42,9 @@ optionalInputArgs(required: $required, anotherRequired: "val")
     }
     {optionalInputArgs: optionalInputArgs}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    required: (a => a)((inp: t_variables).required),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {required: (a => a)((inp: t_variables).required)}: t_variables => Raw.t_variables
+  )
   let makeVariables = (~required, ()): t_variables => {required: required}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/template/generate/nonrecursiveInput.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/nonrecursiveInput.res.txt
@@ -90,95 +90,101 @@ nonrecursiveInput(arg: $arg)
     }
     {nonrecursiveInput: nonrecursiveInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = inp => {
-    nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
-    nullableArray: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).nullableArray),
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).field),
-    enum: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                switch a {
-                | #FIRST => "FIRST"
-                | #SECOND => "SECOND"
-                | #THIRD => "THIRD"
-                }
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).enum),
-    embeddedInput: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) =>
-                        Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).embeddedInput),
-    custom: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).custom),
-  }
-  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = inp => {
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_EmbeddedInput).field),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = (
+    inp => {
+      nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
+      nullableArray: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).nullableArray),
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).field),
+      enum: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  switch a {
+                  | #FIRST => "FIRST"
+                  | #SECOND => "SECOND"
+                  | #THIRD => "THIRD"
+                  }
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).enum),
+      embeddedInput: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) =>
+                          Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).embeddedInput),
+      custom: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).custom),
+    }: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput
+  )
+  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = (
+    inp => {
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_EmbeddedInput).field),
+    }: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectNonrecursiveInput = (
     ~nonNullableField,
@@ -315,96 +321,102 @@ more: scalarsInput(arg: $arg2)
     }
     {scalarsInput, more}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
-    arg2: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg2),
-  }
-  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = inp => {
-    nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
-    nullableArray: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).nullableArray),
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).field),
-    enum: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                switch a {
-                | #FIRST => "FIRST"
-                | #SECOND => "SECOND"
-                | #THIRD => "THIRD"
-                }
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).enum),
-    embeddedInput: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) =>
-                        Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).embeddedInput),
-    custom: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).custom),
-  }
-  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = inp => {
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_EmbeddedInput).field),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
+      arg2: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg2),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = (
+    inp => {
+      nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
+      nullableArray: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).nullableArray),
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).field),
+      enum: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  switch a {
+                  | #FIRST => "FIRST"
+                  | #SECOND => "SECOND"
+                  | #THIRD => "THIRD"
+                  }
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).enum),
+      embeddedInput: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) =>
+                          Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).embeddedInput),
+      custom: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).custom),
+    }: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput
+  )
+  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = (
+    inp => {
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_EmbeddedInput).field),
+    }: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput
+  )
   let makeVariables = (~arg, ~arg2, ()): t_variables => {arg, arg2}
   and makeInputObjectNonrecursiveInput = (
     ~nonNullableField,

--- a/snapshot_tests/operations/expected/template/generate/pokedexScalars.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/pokedexScalars.res.txt
@@ -101,22 +101,24 @@ name
     }
     {pokemon: pokemon}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    id: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).id),
-    name: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).name),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      id: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).id),
+      name: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).name),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~id=?, ~name=?, ()): t_variables => {id, name}
   let makeDefaultVariables = () => makeVariables()
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
@@ -226,22 +228,24 @@ name
     }
     {pokemon: pokemon}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    id: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).id),
-    name: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).name),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      id: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).id),
+      name: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).name),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~id=?, ~name=?, ()): t_variables => {id, name}
   let makeDefaultVariables = () => makeVariables()
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"

--- a/snapshot_tests/operations/expected/template/generate/record.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/record.res.txt
@@ -333,31 +333,27 @@ string
 int  
 }
 "
-    let parse = (
-      (value): t => {
-        string: {
-          let value = (value: Raw.t).string
-          value
-        },
-        int: {
-          let value = (value: Raw.t).int
-          value
-        },
-      }: Raw.t => t
-    )
-    let serialize = (
-      (value): Raw.t => {
-        let int = {
-          let value = (value: t).int
-          value
-        }
-        and string = {
-          let value = (value: t).string
-          value
-        }
-        {string, int}
-      }: t => Raw.t
-    )
+    let parse = (value): t => {
+      string: {
+        let value = (value: Raw.t).string
+        value
+      },
+      int: {
+        let value = (value: Raw.t).int
+        value
+      },
+    }
+    let serialize = (value): Raw.t => {
+      let int = {
+        let value = (value: t).int
+        value
+      }
+      and string = {
+        let value = (value: t).string
+        value
+      }
+      {string, int}
+    }
     let verifyArgsAndParse = (~fragmentName as _Fragment: [#Fragment], value: Raw.t) => parse(value)
     let verifyName = x => switch x {
     | #Fragment => ()
@@ -600,39 +596,35 @@ name
 barkVolume  
 }
 "
-    let parse = (
-      (value): t => {
-        __typename: {
-          let value = (value: Raw.t).__typename
-          value
-        },
-        name: {
-          let value = (value: Raw.t).name
-          value
-        },
-        barkVolume: {
-          let value = (value: Raw.t).barkVolume
-          value
-        },
-      }: Raw.t => t
-    )
-    let serialize = (
-      (value): Raw.t => {
-        let barkVolume = {
-          let value = (value: t).barkVolume
-          value
-        }
-        and name = {
-          let value = (value: t).name
-          value
-        }
-        and __typename = {
-          let value = (value: t).__typename
-          value
-        }
-        {__typename, name, barkVolume}
-      }: t => Raw.t
-    )
+    let parse = (value): t => {
+      __typename: {
+        let value = (value: Raw.t).__typename
+        value
+      },
+      name: {
+        let value = (value: Raw.t).name
+        value
+      },
+      barkVolume: {
+        let value = (value: Raw.t).barkVolume
+        value
+      },
+    }
+    let serialize = (value): Raw.t => {
+      let barkVolume = {
+        let value = (value: t).barkVolume
+        value
+      }
+      and name = {
+        let value = (value: t).name
+        value
+      }
+      and __typename = {
+        let value = (value: t).__typename
+        value
+      }
+      {__typename, name, barkVolume}
+    }
     let verifyArgsAndParse = (~fragmentName as _DogFragment: [#DogFragment], value: Raw.t) =>
       parse(value)
     let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/template/generate/recursiveInput.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/recursiveInput.res.txt
@@ -69,42 +69,46 @@ recursiveInput(arg: $arg)
     }
     {recursiveInput: recursiveInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectRecursiveInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectRecursiveInput: t_variables_RecursiveInput => Raw.t_variables_RecursiveInput = inp => {
-    otherField: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_RecursiveInput).otherField),
-    inner: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => serializeInputObjectRecursiveInput(a))(b))
-        }
-    )((inp: t_variables_RecursiveInput).inner),
-    enum: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                switch a {
-                | #FIRST => "FIRST"
-                | #SECOND => "SECOND"
-                | #THIRD => "THIRD"
-                }
-            )(b),
-          )
-        }
-    )((inp: t_variables_RecursiveInput).enum),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectRecursiveInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectRecursiveInput: t_variables_RecursiveInput => Raw.t_variables_RecursiveInput = (
+    inp => {
+      otherField: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_RecursiveInput).otherField),
+      inner: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => serializeInputObjectRecursiveInput(a))(b))
+          }
+      )((inp: t_variables_RecursiveInput).inner),
+      enum: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  switch a {
+                  | #FIRST => "FIRST"
+                  | #SECOND => "SECOND"
+                  | #THIRD => "THIRD"
+                  }
+              )(b),
+            )
+          }
+      )((inp: t_variables_RecursiveInput).enum),
+    }: t_variables_RecursiveInput => Raw.t_variables_RecursiveInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectRecursiveInput = (
     ~otherField=?,
@@ -200,37 +204,45 @@ recursiveRepro(input: $input)
     }
     {recursiveRepro: recursiveRepro}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    input: (a => serializeInputObjectproblem_input(a))((inp: t_variables).input),
-  }
-  and serializeInputObjectproblem_input: t_variables_problem_input => Raw.t_variables_problem_input = inp => {
-    the_problem: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => serializeInputObjectthis_will_be_duplicated(a))(b))
-        }
-    )((inp: t_variables_problem_input).the_problem),
-    b: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => serializeInputObjectnested_type(a))(b))
-        }
-    )((inp: t_variables_problem_input).b),
-  }
-  and serializeInputObjectthis_will_be_duplicated: t_variables_this_will_be_duplicated => Raw.t_variables_this_will_be_duplicated = inp => {
-    id: (a => a)((inp: t_variables_this_will_be_duplicated).id),
-  }
-  and serializeInputObjectnested_type: t_variables_nested_type => Raw.t_variables_nested_type = inp => {
-    the_problem: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => serializeInputObjectthis_will_be_duplicated(a))(b))
-        }
-    )((inp: t_variables_nested_type).the_problem),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      input: (a => serializeInputObjectproblem_input(a))((inp: t_variables).input),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectproblem_input: t_variables_problem_input => Raw.t_variables_problem_input = (
+    inp => {
+      the_problem: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => serializeInputObjectthis_will_be_duplicated(a))(b))
+          }
+      )((inp: t_variables_problem_input).the_problem),
+      b: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => serializeInputObjectnested_type(a))(b))
+          }
+      )((inp: t_variables_problem_input).b),
+    }: t_variables_problem_input => Raw.t_variables_problem_input
+  )
+  and serializeInputObjectthis_will_be_duplicated: t_variables_this_will_be_duplicated => Raw.t_variables_this_will_be_duplicated = (
+    inp => {
+      id: (a => a)((inp: t_variables_this_will_be_duplicated).id),
+    }: t_variables_this_will_be_duplicated => Raw.t_variables_this_will_be_duplicated
+  )
+  and serializeInputObjectnested_type: t_variables_nested_type => Raw.t_variables_nested_type = (
+    inp => {
+      the_problem: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => serializeInputObjectthis_will_be_duplicated(a))(b))
+          }
+      )((inp: t_variables_nested_type).the_problem),
+    }: t_variables_nested_type => Raw.t_variables_nested_type
+  )
   let makeVariables = (~input, ()): t_variables => {input: input}
   and makeInputObjectproblem_input = (~the_problem=?, ~b=?, ()): t_variables_problem_input => {
     the_problem,

--- a/snapshot_tests/operations/expected/template/generate/scalarsArgs.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/scalarsArgs.res.txt
@@ -98,48 +98,50 @@ scalarsInput(arg: {nullableString: $nullableString, string: $string, nullableInt
     }
     {scalarsInput: scalarsInput}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    nullableString: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableString),
-    string: (a => a)((inp: t_variables).string),
-    nullableInt: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableInt),
-    int: (a => a)((inp: t_variables).int),
-    nullableFloat: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableFloat),
-    float: (a => a)((inp: t_variables).float),
-    nullableBoolean: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableBoolean),
-    boolean: (a => a)((inp: t_variables).boolean),
-    nullableID: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableID),
-    id: (a => a)((inp: t_variables).id),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      nullableString: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableString),
+      string: (a => a)((inp: t_variables).string),
+      nullableInt: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableInt),
+      int: (a => a)((inp: t_variables).int),
+      nullableFloat: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableFloat),
+      float: (a => a)((inp: t_variables).float),
+      nullableBoolean: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableBoolean),
+      boolean: (a => a)((inp: t_variables).boolean),
+      nullableID: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableID),
+      id: (a => a)((inp: t_variables).id),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (
     ~nullableString=?,
     ~string,

--- a/snapshot_tests/operations/expected/template/generate/scalarsInput.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/scalarsInput.res.txt
@@ -104,51 +104,55 @@ scalarsInput(arg: $arg)
     }
     {scalarsInput: scalarsInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectVariousScalarsInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectVariousScalarsInput: t_variables_VariousScalarsInput => Raw.t_variables_VariousScalarsInput = inp => {
-    nullableString: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableString),
-    string: (a => a)((inp: t_variables_VariousScalarsInput).string),
-    nullableInt: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableInt),
-    int: (a => a)((inp: t_variables_VariousScalarsInput).int),
-    nullableFloat: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableFloat),
-    float: (a => a)((inp: t_variables_VariousScalarsInput).float),
-    nullableBoolean: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableBoolean),
-    boolean: (a => a)((inp: t_variables_VariousScalarsInput).boolean),
-    nullableID: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableID),
-    id: (a => a)((inp: t_variables_VariousScalarsInput).id),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectVariousScalarsInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectVariousScalarsInput: t_variables_VariousScalarsInput => Raw.t_variables_VariousScalarsInput = (
+    inp => {
+      nullableString: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableString),
+      string: (a => a)((inp: t_variables_VariousScalarsInput).string),
+      nullableInt: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableInt),
+      int: (a => a)((inp: t_variables_VariousScalarsInput).int),
+      nullableFloat: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableFloat),
+      float: (a => a)((inp: t_variables_VariousScalarsInput).float),
+      nullableBoolean: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableBoolean),
+      boolean: (a => a)((inp: t_variables_VariousScalarsInput).boolean),
+      nullableID: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableID),
+      id: (a => a)((inp: t_variables_VariousScalarsInput).id),
+    }: t_variables_VariousScalarsInput => Raw.t_variables_VariousScalarsInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectVariousScalarsInput = (
     ~nullableString=?,

--- a/snapshot_tests/operations/expected/template/generate/skipDirectives.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/skipDirectives.res.txt
@@ -164,9 +164,9 @@ string @include(if: $var)
     }
     {v1, v2}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    var: (a => a)((inp: t_variables).var),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {var: (a => a)((inp: t_variables).var)}: t_variables => Raw.t_variables
+  )
   let makeVariables = (~var, ()): t_variables => {var: var}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/template/generate/tagged_template.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/tagged_template.res.txt
@@ -1545,59 +1545,55 @@ nullableOfNonNullable
     ],
     [],
   )
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment: [#ListFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -1847,59 +1843,55 @@ nullableOfNonNullable
     ],
     [],
   )
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment8: [#ListFragment8], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/template/generate/union.res.txt
+++ b/snapshot_tests/operations/expected/template/generate/union.res.txt
@@ -541,31 +541,27 @@ name
 __typename  
 }
 "
-    let parse = (
-      (value): named => {
-        name: {
-          let value = (value: Raw.t).name
-          value
-        },
-        __typename: {
-          let value = (value: Raw.t).__typename
-          value
-        },
-      }: Raw.t => named
-    )
-    let serialize = (
-      (value): Raw.t => {
-        let __typename = {
-          let value = (value: named).__typename
-          value
-        }
-        and name = {
-          let value = (value: named).name
-          value
-        }
-        {name, __typename}
-      }: named => Raw.t
-    )
+    let parse = (value): named => {
+      name: {
+        let value = (value: Raw.t).name
+        value
+      },
+      __typename: {
+        let value = (value: Raw.t).__typename
+        value
+      },
+    }
+    let serialize = (value): Raw.t => {
+      let __typename = {
+        let value = (value: named).__typename
+        value
+      }
+      and name = {
+        let value = (value: named).name
+        value
+      }
+      {name, __typename}
+    }
     let verifyArgsAndParse = (~fragmentName as _DogFields: [#DogFields], value: Raw.t) =>
       parse(value)
     let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/uncurried/compile/fragmentDefinition.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/compile/fragmentDefinition.res.txt
@@ -266,37 +266,39 @@ var Raw$5 = {};
 var query$3 = "query MyQuery($arg1: String)  {\nl1: lists  {\n...ListFragment   \n}\n\nl2: lists  {\n...ListFragment   \n...ListFragment   \n}\n\nl3: lists  {\nnullableOfNullable  \n...ListFragment   \n...ListFragment   \n}\n\nl4: lists  {\nnullableOfNullable  \n...InlineListFragment   \n}\n\nl5: lists  {\n...FragmentWithArgs   \n}\n\n}\nfragment FragmentWithArgs on Lists   {\nlistWithArg(arg1: $arg1)  \n}\nfragment ListFragment on Lists   {\nnullableOfNullable  \nnullableOfNonNullable  \n}\nfragment InlineListFragment on Lists   {\nnullableOfNullable  \nnullableOfNonNullable  \n}\n";
 
 function parse$5(value) {
-  var value$1 = value.l2;
-  var value$2 = value.l3;
-  var value$3 = value$2["nullableOfNullable"];
-  var value$4 = value.l4;
-  var value$5 = value$4["nullableOfNullable"];
+  var value$1 = value.l1;
+  var value$2 = value.l2;
+  var value$3 = value.l3;
+  var value$4 = value$3["nullableOfNullable"];
+  var value$5 = value.l4;
+  var value$6 = value$5["nullableOfNullable"];
+  var value$7 = value.l5;
   return {
-          l1: parse(value.l1),
+          l1: parse(value$1),
           l2: {
-            frag1: parse(value$1),
-            frag2: parse(value$1)
-          },
-          l3: {
-            nullableOfNullable: !(value$3 == null) ? value$3.map(function (value) {
-                    if (!(value == null)) {
-                      return value;
-                    }
-                    
-                  }) : undefined,
             frag1: parse(value$2),
             frag2: parse(value$2)
           },
-          l4: {
-            nullableOfNullable: !(value$5 == null) ? value$5.map(function (value) {
+          l3: {
+            nullableOfNullable: !(value$4 == null) ? value$4.map(function (value) {
                     if (!(value == null)) {
                       return value;
                     }
                     
                   }) : undefined,
-            inlineListFragment: parse$3(value$4)
+            frag1: parse(value$3),
+            frag2: parse(value$3)
           },
-          l5: parse$2(value.l5)
+          l4: {
+            nullableOfNullable: !(value$6 == null) ? value$6.map(function (value) {
+                    if (!(value == null)) {
+                      return value;
+                    }
+                    
+                  }) : undefined,
+            inlineListFragment: parse$3(value$5)
+          },
+          l5: parse$2(value$7)
         };
 }
 
@@ -380,8 +382,9 @@ var Raw$6 = {};
 var query$4 = "query   {\nlists  {\n...ListFragment   \n}\n\n}\nfragment ListFragment on Lists   {\nnullableOfNullable  \nnullableOfNonNullable  \n}\n";
 
 function parse$6(value) {
+  var value$1 = value.lists;
   return {
-          lists: parse(value.lists)
+          lists: parse(value$1)
         };
 }
 

--- a/snapshot_tests/operations/expected/uncurried/compile/fragmentWithdifferentReturnType.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/compile/fragmentWithdifferentReturnType.res.txt
@@ -70,8 +70,9 @@ lists  {
 ${query}`;
 
 function parse$1(value) {
+  var value$1 = value.lists;
   return {
-          lists: parse(value.lists)
+          lists: parse(value$1)
         };
 }
 

--- a/snapshot_tests/operations/expected/uncurried/compile/record.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/compile/record.res.txt
@@ -197,8 +197,9 @@ var Raw$4 = {};
 var query$1 = "query   {\nvariousScalars  {\n...Fragment   \n}\n\n}\nfragment Fragment on VariousScalars   {\nstring  \nint  \n}\n";
 
 function parse$4(value) {
+  var value$1 = value.variousScalars;
   return {
-          variousScalars: parse$3(value.variousScalars)
+          variousScalars: parse$3(value$1)
         };
 }
 

--- a/snapshot_tests/operations/expected/uncurried/compile/tagged_template.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/compile/tagged_template.res.txt
@@ -673,8 +673,9 @@ lists  {
 ${query$6}`;
 
 function parse$7(value) {
+  var value$1 = value.lists;
   return {
-          lists: parse$6(value.lists)
+          lists: parse$6(value$1)
         };
 }
 
@@ -719,8 +720,9 @@ lists  {
 ${query$6}`;
 
 function parse$8(value) {
+  var value$1 = value.lists;
   return {
-          lists: parse$6(value.lists)
+          lists: parse$6(value$1)
         };
 }
 
@@ -765,8 +767,9 @@ lists  {
 ${query$6}`;
 
 function parse$9(value) {
+  var value$1 = value.lists;
   return {
-          lists: parse$6(value.lists)
+          lists: parse$6(value$1)
         };
 }
 
@@ -864,25 +867,26 @@ var query$11 = ApolloClient.gql([
     ], query$10);
 
 function parse$11(value) {
-  var value$1 = value.variousScalars;
-  var value$2 = value$1.nullableString;
-  var value$3 = value$1.nullableInt;
-  var value$4 = value$1.nullableFloat;
-  var value$5 = value$1.nullableBoolean;
-  var value$6 = value$1.nullableID;
+  var value$1 = value.lists;
+  var value$2 = value.variousScalars;
+  var value$3 = value$2.nullableString;
+  var value$4 = value$2.nullableInt;
+  var value$5 = value$2.nullableFloat;
+  var value$6 = value$2.nullableBoolean;
+  var value$7 = value$2.nullableID;
   return {
-          lists: parse$10(value.lists),
+          lists: parse$10(value$1),
           variousScalars: {
-            nullableString: !(value$2 == null) ? value$2 : undefined,
-            string: value$1.string,
-            nullableInt: !(value$3 == null) ? value$3 : undefined,
-            int: value$1.int,
-            nullableFloat: !(value$4 == null) ? value$4 : undefined,
-            float: value$1.float,
-            nullableBoolean: !(value$5 == null) ? value$5 : undefined,
-            boolean: value$1.boolean,
-            nullableID: !(value$6 == null) ? value$6 : undefined,
-            id: value$1.id
+            nullableString: !(value$3 == null) ? value$3 : undefined,
+            string: value$2.string,
+            nullableInt: !(value$4 == null) ? value$4 : undefined,
+            int: value$2.int,
+            nullableFloat: !(value$5 == null) ? value$5 : undefined,
+            float: value$2.float,
+            nullableBoolean: !(value$6 == null) ? value$6 : undefined,
+            boolean: value$2.boolean,
+            nullableID: !(value$7 == null) ? value$7 : undefined,
+            id: value$2.id
           }
         };
 }

--- a/snapshot_tests/operations/expected/uncurried/generate/argNamedQuery.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/argNamedQuery.res.txt
@@ -42,9 +42,9 @@ argNamedQuery(query: $query)
     }
     {argNamedQuery: argNamedQuery}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    query: (a => a)((inp: t_variables).query),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {query: (a => a)((inp: t_variables).query)}: t_variables => Raw.t_variables
+  )
   let makeVariables = (~query, ()): t_variables => {query: query}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"
@@ -95,9 +95,9 @@ argNamedQuery(query: $query)
       }
       {argNamedQuery: argNamedQuery}
     }
-    let serializeVariables: t_variables => Raw.t_variables = inp => {
-      query: (a => a)((inp: t_variables).query),
-    }
+    let serializeVariables: t_variables => Raw.t_variables = (
+      inp => {query: (a => a)((inp: t_variables).query)}: t_variables => Raw.t_variables
+    )
     let makeVariables = (~query, ()): t_variables => {query: query}
     external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
     external toJson: Raw.t => Js.Json.t = "%identity"
@@ -147,9 +147,9 @@ argNamedQuery(query: $query)
       }
       {argNamedQuery: argNamedQuery}
     }
-    let serializeVariables: t_variables => Raw.t_variables = inp => {
-      query: (a => a)((inp: t_variables).query),
-    }
+    let serializeVariables: t_variables => Raw.t_variables = (
+      inp => {query: (a => a)((inp: t_variables).query)}: t_variables => Raw.t_variables
+    )
     let makeVariables = (~query, ()): t_variables => {query: query}
     external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
     external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/uncurried/generate/comment.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/comment.res.txt
@@ -90,95 +90,101 @@ nonrecursiveInput(arg: $arg)
     }
     {nonrecursiveInput: nonrecursiveInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = inp => {
-    nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
-    nullableArray: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).nullableArray),
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).field),
-    enum: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                switch a {
-                | #FIRST => "FIRST"
-                | #SECOND => "SECOND"
-                | #THIRD => "THIRD"
-                }
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).enum),
-    embeddedInput: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) =>
-                        Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).embeddedInput),
-    custom: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).custom),
-  }
-  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = inp => {
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_EmbeddedInput).field),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = (
+    inp => {
+      nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
+      nullableArray: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).nullableArray),
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).field),
+      enum: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  switch a {
+                  | #FIRST => "FIRST"
+                  | #SECOND => "SECOND"
+                  | #THIRD => "THIRD"
+                  }
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).enum),
+      embeddedInput: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) =>
+                          Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).embeddedInput),
+      custom: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).custom),
+    }: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput
+  )
+  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = (
+    inp => {
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_EmbeddedInput).field),
+    }: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectNonrecursiveInput = (
     ~nonNullableField,

--- a/snapshot_tests/operations/expected/uncurried/generate/customScalars.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/customScalars.res.txt
@@ -88,16 +88,18 @@ nonNullable
     }
     {customScalarField: customScalarField}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    opt: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).opt),
-    req: (a => a)((inp: t_variables).req),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      opt: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).opt),
+      req: (a => a)((inp: t_variables).req),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~opt=?, ~req, ()): t_variables => {opt, req}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/uncurried/generate/customTypes.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/customTypes.res.txt
@@ -25,21 +25,25 @@ module NullableString = {
     | Red
     | Green
     | Blue
-  let parse: option<string> => t = color =>
-    switch color {
-    | Some("green") => Green
-    | Some("blue") => Blue
-    | Some("red") => Red
-    | Some(_)
-    | None =>
-      Red
-    }
-  let serialize: t => option<string> = color =>
-    switch color {
-    | Red => Some("red")
-    | Green => Some("green")
-    | Blue => Some("blue")
-    }
+  let parse: option<string> => t = (
+    color =>
+      switch color {
+      | Some("green") => Green
+      | Some("blue") => Blue
+      | Some("red") => Red
+      | Some(_)
+      | None =>
+        Red
+      }: option<string> => t
+  )
+  let serialize: t => option<string> = (
+    color =>
+      switch color {
+      | Red => Some("red")
+      | Green => Some("green")
+      | Blue => Some("blue")
+      }: t => option<string>
+  )
 }
 
 module DateTime = {

--- a/snapshot_tests/operations/expected/uncurried/generate/enumInput.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/enumInput.res.txt
@@ -42,16 +42,18 @@ enumInput(arg: $arg)
     }
     {enumInput: enumInput}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (
-      a =>
-        switch a {
-        | #FIRST => "FIRST"
-        | #SECOND => "SECOND"
-        | #THIRD => "THIRD"
-        }
-    )((inp: t_variables).arg),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (
+        a =>
+          switch a {
+          | #FIRST => "FIRST"
+          | #SECOND => "SECOND"
+          | #THIRD => "THIRD"
+          }
+      )((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/uncurried/generate/ewert_reproduction.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/ewert_reproduction.res.txt
@@ -49,60 +49,56 @@ lastname
 
 }
 "
-  let parse = (
-    (value): t => {
-      user: {
-        let value = (value: Raw.t).user
-        (
-          {
-            id: {
-              let value = (value: Raw.t_user).id
-              value
-            },
-            firstname: {
-              let value = (value: Raw.t_user).firstname
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            },
-            lastname: {
-              let value = (value: Raw.t_user).lastname
-              value
-            },
-          }: t_user
-        )
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let user = {
-        let value = (value: t).user
-        (
-          {
-            let lastname = {
-              let value = (value: t_user).lastname
-              value
+  let parse = (value): t => {
+    user: {
+      let value = (value: Raw.t).user
+      (
+        {
+          id: {
+            let value = (value: Raw.t_user).id
+            value
+          },
+          firstname: {
+            let value = (value: Raw.t_user).firstname
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
             }
-            and firstname = {
-              let value = (value: t_user).firstname
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
+          },
+          lastname: {
+            let value = (value: Raw.t_user).lastname
+            value
+          },
+        }: t_user
+      )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let user = {
+      let value = (value: t).user
+      (
+        {
+          let lastname = {
+            let value = (value: t_user).lastname
+            value
+          }
+          and firstname = {
+            let value = (value: t_user).firstname
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
             }
-            and id = {
-              let value = (value: t_user).id
-              value
-            }
-            {id, firstname, lastname}
-          }: Raw.t_user
-        )
-      }
-      {user: user}
-    }: t => Raw.t
-  )
+          }
+          and id = {
+            let value = (value: t_user).id
+            value
+          }
+          {id, firstname, lastname}
+        }: Raw.t_user
+      )
+    }
+    {user: user}
+  }
   let verifyArgsAndParse = (
     ~userId as _userId: [#NonNull_String],
     ~fragmentName as _UserData: [#UserData],

--- a/snapshot_tests/operations/expected/uncurried/generate/fragmentDefinition.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/fragmentDefinition.res.txt
@@ -709,15 +709,17 @@ l5: lists  {
     }
     {l1, l2, l3, l4, l5}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg1: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).arg1),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg1: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).arg1),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~arg1=?, ()): t_variables => {arg1: arg1}
   let makeDefaultVariables = () => makeVariables()
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"

--- a/snapshot_tests/operations/expected/uncurried/generate/fragmentDefinition.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/fragmentDefinition.res.txt
@@ -45,59 +45,55 @@ nullableOfNullable
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment: [#ListFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -136,29 +132,25 @@ function back to the original JSON-compatible data ")
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNonNullable: nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNonNullable: nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _Another: [#Another], value: Raw.t) => parse(value)
   let verifyName = x => switch x {
   | #Another => ()
@@ -196,45 +188,41 @@ function back to the original JSON-compatible data ")
 listWithArg(arg1: $arg1)  
 }
 "
-  let parse = (
-    (value): t => {
-      listWithArg: {
-        let value = (value: Raw.t).listWithArg
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let listWithArg = {
-        let value = (value: t).listWithArg
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    listWithArg: {
+      let value = (value: Raw.t).listWithArg
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      {listWithArg: listWithArg}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let listWithArg = {
+      let value = (value: t).listWithArg
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {listWithArg: listWithArg}
+  }
   let verifyArgsAndParse = (
     ~arg1 as _arg1: [#String],
     ~fragmentName as _FragmentWithArgs: [#FragmentWithArgs],
@@ -266,59 +254,55 @@ nullableOfNullable
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (
     ~fragmentName as _InlineListFragment: [#InlineListFragment],
     value: Raw.t,
@@ -349,59 +333,55 @@ nullableOfNullable
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (
     ~fragmentName as _InlineListFragment: [#InlineListFragment],
     value: Raw.t,

--- a/snapshot_tests/operations/expected/uncurried/generate/fragmentInFragment.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/fragmentInFragment.res.txt
@@ -32,45 +32,41 @@ function back to the original JSON-compatible data ")
 nullableOfNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      {nullableOfNullable: nullableOfNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable: nullableOfNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment: [#ListFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -119,59 +115,55 @@ nullableOfNullable
 ",
     ListFragment.query,
   )
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "nullableOfNullable"))
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      listFragment: {
-        let value = (Obj.magic(value): ListFragment.Raw.t)
-
-        ListFragment.verifyArgsAndParse(~fragmentName=#ListFragment, value)
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t =>
-      Obj.magic(
-        Js.Array2.reduce(
-          [(Obj.magic(ListFragment.serialize((value: t).listFragment)): Js.Json.t)],
-          Graphql_ppx_runtime.deepMerge,
-          (
-            Obj.magic({
-              let nullableOfNullable = {
-                let value = (value: t).nullableOfNullable
-                switch value {
-                | Some(value) =>
-                  Js.Nullable.return(
-                    Js.Array2.map(value, value =>
-                      switch value {
-                      | Some(value) => Js.Nullable.return(value)
-                      | None => Js.Nullable.null
-                      }
-                    ),
-                  )
-                | None => Js.Nullable.null
-                }
-              }
-              {"nullableOfNullable": nullableOfNullable}
-            }): Js.Json.t
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "nullableOfNullable"))
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
           ),
+        )
+      | None => None
+      }
+    },
+    listFragment: {
+      let value = (Obj.magic(value): ListFragment.Raw.t)
+
+      ListFragment.verifyArgsAndParse(~fragmentName=#ListFragment, value)
+    },
+  }
+  let serialize = (value): Raw.t =>
+    Obj.magic(
+      Js.Array2.reduce(
+        [(Obj.magic(ListFragment.serialize((value: t).listFragment)): Js.Json.t)],
+        Graphql_ppx_runtime.deepMerge,
+        (
+          Obj.magic({
+            let nullableOfNullable = {
+              let value = (value: t).nullableOfNullable
+              switch value {
+              | Some(value) =>
+                Js.Nullable.return(
+                  Js.Array2.map(value, value =>
+                    switch value {
+                    | Some(value) => Js.Nullable.return(value)
+                    | None => Js.Nullable.null
+                    }
+                  ),
+                )
+              | None => Js.Nullable.null
+              }
+            }
+            {"nullableOfNullable": nullableOfNullable}
+          }): Js.Json.t
         ),
-      ): t => Raw.t
-  )
+      ),
+    )
   let verifyArgsAndParse = (~fragmentName as _Another: [#Another], value: Raw.t) => parse(value)
   let verifyName = x => switch x {
   | #Another => ()

--- a/snapshot_tests/operations/expected/uncurried/generate/fragmentOnInterface.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/fragmentOnInterface.res.txt
@@ -45,23 +45,19 @@ __typename
 id  
 }
 "
-  let parse = (
-    (value): t => {
-      id: {
-        let value = (value: Raw.t).id
-        value
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let id = {
-        let value = (value: t).id
-        value
-      }
-      {id: id}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    id: {
+      let value = (value: Raw.t).id
+      value
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let id = {
+      let value = (value: t).id
+      value
+    }
+    {id: id}
+  }
   let verifyArgsAndParse = (
     ~fragmentName as _InterfaceFragment: [#InterfaceFragment],
     value: Raw.t,
@@ -119,37 +115,33 @@ id
 ",
     InterfaceFragment.query,
   )
-  let parse = (
-    (value): t => {
-      id: {
-        let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "id"))
-        value
-      },
-      interfaceFragment: {
-        let value = (Obj.magic(value): InterfaceFragment.Raw.t)
+  let parse = (value): t => {
+    id: {
+      let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "id"))
+      value
+    },
+    interfaceFragment: {
+      let value = (Obj.magic(value): InterfaceFragment.Raw.t)
 
-        InterfaceFragment.verifyArgsAndParse(~fragmentName=#InterfaceFragment, value)
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t =>
-      Obj.magic(
-        Js.Array2.reduce(
-          [(Obj.magic(InterfaceFragment.serialize((value: t).interfaceFragment)): Js.Json.t)],
-          Graphql_ppx_runtime.deepMerge,
-          (
-            Obj.magic({
-              let id = {
-                let value = (value: t).id
-                value
-              }
-              {"id": id}
-            }): Js.Json.t
-          ),
+      InterfaceFragment.verifyArgsAndParse(~fragmentName=#InterfaceFragment, value)
+    },
+  }
+  let serialize = (value): Raw.t =>
+    Obj.magic(
+      Js.Array2.reduce(
+        [(Obj.magic(InterfaceFragment.serialize((value: t).interfaceFragment)): Js.Json.t)],
+        Graphql_ppx_runtime.deepMerge,
+        (
+          Obj.magic({
+            let id = {
+              let value = (value: t).id
+              value
+            }
+            {"id": id}
+          }): Js.Json.t
         ),
-      ): t => Raw.t
-  )
+      ),
+    )
   let verifyArgsAndParse = (~fragmentName as _AnotherFragment: [#AnotherFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -192,37 +184,33 @@ id
 ",
     InterfaceFragment.query,
   )
-  let parse = (
-    (value): t => {
-      id: {
-        let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "id"))
-        value
-      },
-      interfaceFragment: {
-        let value = (Obj.magic(value): InterfaceFragment.Raw.t)
+  let parse = (value): t => {
+    id: {
+      let value = Obj.magic(Js.Dict.unsafeGet(Obj.magic(value), "id"))
+      value
+    },
+    interfaceFragment: {
+      let value = (Obj.magic(value): InterfaceFragment.Raw.t)
 
-        InterfaceFragment.verifyArgsAndParse(~fragmentName=#InterfaceFragment, value)
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t =>
-      Obj.magic(
-        Js.Array2.reduce(
-          [(Obj.magic(InterfaceFragment.serialize((value: t).interfaceFragment)): Js.Json.t)],
-          Graphql_ppx_runtime.deepMerge,
-          (
-            Obj.magic({
-              let id = {
-                let value = (value: t).id
-                value
-              }
-              {"id": id}
-            }): Js.Json.t
-          ),
+      InterfaceFragment.verifyArgsAndParse(~fragmentName=#InterfaceFragment, value)
+    },
+  }
+  let serialize = (value): Raw.t =>
+    Obj.magic(
+      Js.Array2.reduce(
+        [(Obj.magic(InterfaceFragment.serialize((value: t).interfaceFragment)): Js.Json.t)],
+        Graphql_ppx_runtime.deepMerge,
+        (
+          Obj.magic({
+            let id = {
+              let value = (value: t).id
+              value
+            }
+            {"id": id}
+          }): Js.Json.t
         ),
-      ): t => Raw.t
-  )
+      ),
+    )
   let verifyArgsAndParse = (~fragmentName as _AnonUser: [#AnonUser], value: Raw.t) => parse(value)
   let verifyName = x => switch x {
   | #AnonUser => ()

--- a/snapshot_tests/operations/expected/uncurried/generate/fragmentUnion.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/fragmentUnion.res.txt
@@ -37,23 +37,19 @@ function back to the original JSON-compatible data ")
 name  
 }
 "
-  let parse = (
-    (value): t => {
-      name: {
-        let value = (value: Raw.t).name
-        value
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let name = {
-        let value = (value: t).name
-        value
-      }
-      {name: name}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    name: {
+      let value = (value: Raw.t).name
+      value
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let name = {
+      let value = (value: t).name
+      value
+    }
+    {name: name}
+  }
   let verifyArgsAndParse = (~fragmentName as _DogFragment: [#DogFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -92,23 +88,19 @@ function back to the original JSON-compatible data ")
 name  
 }
 "
-  let parse = (
-    (value): t => {
-      name: {
-        let value = (value: Raw.t).name
-        value
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let name = {
-        let value = (value: t).name
-        value
-      }
-      {name: name}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    name: {
+      let value = (value: Raw.t).name
+      value
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let name = {
+      let value = (value: t).name
+      value
+    }
+    {name: name}
+  }
   let verifyArgsAndParse = (~fragmentName as _HumanFragment: [#HumanFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/uncurried/generate/fragmentUnion.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/fragmentUnion.res.txt
@@ -1,9 +1,11 @@
 module Graphql_ppx_runtime = {
   // mock
-  let assign_typename: (
-    Js.Json.t,
-    string,
-  ) => Js.Json.t = %raw(` (obj, typename) => { obj.__typename = typename; return obj } `)
+  let assign_typename: (Js.Json.t, string) => Js.Json.t = (
+    %raw(` (obj, typename) => { obj.__typename = typename; return obj } `): (
+      Js.Json.t,
+      string,
+    ) => Js.Json.t
+  )
 }
 module DogFragment: {
   @@ocaml.warning("-32-30")

--- a/snapshot_tests/operations/expected/uncurried/generate/fragmentWithdifferentReturnType.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/fragmentWithdifferentReturnType.res.txt
@@ -41,59 +41,55 @@ nullableOfNullable
 nullableOfNonNullable  
 }
 "
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment: [#ListFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/uncurried/generate/fragmentvariableinput.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/fragmentvariableinput.res.txt
@@ -35,54 +35,50 @@ id
 
 }
 "
-  let parse = (
-    (value): t => {
-      reposts: {
-        let value = (value: Raw.t).reposts
-        Js.Array2.map(value, value =>
-          switch Js.toOption(value) {
-          | Some(value) =>
-            Some(
-              (
-                {
-                  id: {
-                    let value = (value: Raw.t_reposts).id
-                    value
-                  },
-                }: t_reposts
-              ),
-            )
-          | None => None
-          }
-        )
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let reposts = {
-        let value = (value: t).reposts
-        Js.Array2.map(value, value =>
-          switch value {
-          | Some(value) =>
-            Js.Nullable.return(
-              (
-                {
-                  let id = {
-                    let value = (value: t_reposts).id
-                    value
-                  }
-                  {id: id}
-                }: Raw.t_reposts
-              ),
-            )
-          | None => Js.Nullable.null
-          }
-        )
-      }
-      {reposts: reposts}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    reposts: {
+      let value = (value: Raw.t).reposts
+      Js.Array2.map(value, value =>
+        switch Js.toOption(value) {
+        | Some(value) =>
+          Some(
+            (
+              {
+                id: {
+                  let value = (value: Raw.t_reposts).id
+                  value
+                },
+              }: t_reposts
+            ),
+          )
+        | None => None
+        }
+      )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let reposts = {
+      let value = (value: t).reposts
+      Js.Array2.map(value, value =>
+        switch value {
+        | Some(value) =>
+          Js.Nullable.return(
+            (
+              {
+                let id = {
+                  let value = (value: t_reposts).id
+                  value
+                }
+                {id: id}
+              }: Raw.t_reposts
+            ),
+          )
+        | None => Js.Nullable.null
+        }
+      )
+    }
+    {reposts: reposts}
+  }
   let verifyArgsAndParse = (
     ~name as _name: [#NonNull_String],
     ~fragmentName as _test: [#test],

--- a/snapshot_tests/operations/expected/uncurried/generate/hasuraRepro.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/hasuraRepro.res.txt
@@ -28,23 +28,19 @@ function back to the original JSON-compatible data ")
 name  
 }
 "
-  let parse = (
-    (value): t => {
-      name: {
-        let value = (value: Raw.t).name
-        value
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let name = {
-        let value = (value: t).name
-        value
-      }
-      {name: name}
-    }: t => Raw.t
-  )
+  let parse = (value): t => {
+    name: {
+      let value = (value: Raw.t).name
+      value
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let name = {
+      let value = (value: t).name
+      value
+    }
+    {name: name}
+  }
   let verifyArgsAndParse = (~fragmentName as _Dog: [#Dog], value: Raw.t) => parse(value)
   let verifyName = x => switch x {
   | #Dog => ()

--- a/snapshot_tests/operations/expected/uncurried/generate/hasuraRepro.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/hasuraRepro.res.txt
@@ -118,22 +118,24 @@ hasuraRepro(orderBy: [{id: desc}], block: {number: $blockNumber, type: $type})  
     }
     {hasuraRepro: hasuraRepro}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    blockNumber: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).blockNumber),
-    type_: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).type_),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      blockNumber: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).blockNumber),
+      type_: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).type_),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~blockNumber=?, ~type_=?, ()): t_variables => {blockNumber, type_}
   let makeDefaultVariables = () => makeVariables()
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"

--- a/snapshot_tests/operations/expected/uncurried/generate/listsArgs.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/listsArgs.res.txt
@@ -68,51 +68,53 @@ listsInput(arg: {nullableOfNullable: $nullableOfNullable, nullableOfNonNullable:
     }
     {listsInput: listsInput}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    nullableOfNullable: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      nullableOfNullable: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables).nullableOfNullable),
+      nullableOfNonNullable: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => Js.Array2.map(a, b => (a => a)(b)))(b))
+          }
+      )((inp: t_variables).nullableOfNonNullable),
+      nonNullableOfNullable: (
+        a =>
+          Js.Array2.map(a, b =>
             (
               a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
+                switch a {
+                | None => Js.Nullable.undefined
+                | Some(b) => Js.Nullable.return((a => a)(b))
+                }
+            )(b)
           )
-        }
-    )((inp: t_variables).nullableOfNullable),
-    nullableOfNonNullable: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => Js.Array2.map(a, b => (a => a)(b)))(b))
-        }
-    )((inp: t_variables).nullableOfNonNullable),
-    nonNullableOfNullable: (
-      a =>
-        Js.Array2.map(a, b =>
-          (
-            a =>
-              switch a {
-              | None => Js.Nullable.undefined
-              | Some(b) => Js.Nullable.return((a => a)(b))
-              }
-          )(b)
-        )
-    )((inp: t_variables).nonNullableOfNullable),
-    nonNullableOfNonNullable: (a => Js.Array2.map(a, b => (a => a)(b)))(
-      (inp: t_variables).nonNullableOfNonNullable,
-    ),
-  }
+      )((inp: t_variables).nonNullableOfNullable),
+      nonNullableOfNonNullable: (a => Js.Array2.map(a, b => (a => a)(b)))(
+        (inp: t_variables).nonNullableOfNonNullable,
+      ),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (
     ~nullableOfNullable=?,
     ~nullableOfNonNullable=?,

--- a/snapshot_tests/operations/expected/uncurried/generate/listsInput.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/listsInput.res.txt
@@ -74,54 +74,58 @@ listsInput(arg: $arg)
     }
     {listsInput: listsInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectListsInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectListsInput: t_variables_ListsInput => Raw.t_variables_ListsInput = inp => {
-    nullableOfNullable: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectListsInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectListsInput: t_variables_ListsInput => Raw.t_variables_ListsInput = (
+    inp => {
+      nullableOfNullable: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_ListsInput).nullableOfNullable),
+      nullableOfNonNullable: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => Js.Array2.map(a, b => (a => a)(b)))(b))
+          }
+      )((inp: t_variables_ListsInput).nullableOfNonNullable),
+      nonNullableOfNullable: (
+        a =>
+          Js.Array2.map(a, b =>
             (
               a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
+                switch a {
+                | None => Js.Nullable.undefined
+                | Some(b) => Js.Nullable.return((a => a)(b))
+                }
+            )(b)
           )
-        }
-    )((inp: t_variables_ListsInput).nullableOfNullable),
-    nullableOfNonNullable: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => Js.Array2.map(a, b => (a => a)(b)))(b))
-        }
-    )((inp: t_variables_ListsInput).nullableOfNonNullable),
-    nonNullableOfNullable: (
-      a =>
-        Js.Array2.map(a, b =>
-          (
-            a =>
-              switch a {
-              | None => Js.Nullable.undefined
-              | Some(b) => Js.Nullable.return((a => a)(b))
-              }
-          )(b)
-        )
-    )((inp: t_variables_ListsInput).nonNullableOfNullable),
-    nonNullableOfNonNullable: (a => Js.Array2.map(a, b => (a => a)(b)))(
-      (inp: t_variables_ListsInput).nonNullableOfNonNullable,
-    ),
-  }
+      )((inp: t_variables_ListsInput).nonNullableOfNullable),
+      nonNullableOfNonNullable: (a => Js.Array2.map(a, b => (a => a)(b)))(
+        (inp: t_variables_ListsInput).nonNullableOfNonNullable,
+      ),
+    }: t_variables_ListsInput => Raw.t_variables_ListsInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectListsInput = (
     ~nullableOfNullable=?,

--- a/snapshot_tests/operations/expected/uncurried/generate/module_type.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/module_type.res.txt
@@ -263,8 +263,10 @@ and VariousScalars: {
   let parse = (nestedObject: MyQueryRecursive.t_nestedObject) => {
     otherInner: nestedObject.inner,
   }
-  let serialize: t => MyQueryRecursive.t_nestedObject = t => {
-    inner: t.otherInner,
-  }
+  let serialize: t => MyQueryRecursive.t_nestedObject = (
+    t => {
+      inner: t.otherInner,
+    }: t => MyQueryRecursive.t_nestedObject
+  )
 }
 

--- a/snapshot_tests/operations/expected/uncurried/generate/mutationWithArgs.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/mutationWithArgs.res.txt
@@ -42,9 +42,9 @@ optionalInputArgs(required: $required, anotherRequired: "val")
     }
     {optionalInputArgs: optionalInputArgs}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    required: (a => a)((inp: t_variables).required),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {required: (a => a)((inp: t_variables).required)}: t_variables => Raw.t_variables
+  )
   let makeVariables = (~required, ()): t_variables => {required: required}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/uncurried/generate/mutationWithArgsAndNoRecords.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/mutationWithArgsAndNoRecords.res.txt
@@ -42,9 +42,9 @@ optionalInputArgs(required: $required, anotherRequired: "val")
     }
     {optionalInputArgs: optionalInputArgs}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    required: (a => a)((inp: t_variables).required),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {required: (a => a)((inp: t_variables).required)}: t_variables => Raw.t_variables
+  )
   let makeVariables = (~required, ()): t_variables => {required: required}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/uncurried/generate/nonrecursiveInput.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/nonrecursiveInput.res.txt
@@ -90,95 +90,101 @@ nonrecursiveInput(arg: $arg)
     }
     {nonrecursiveInput: nonrecursiveInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = inp => {
-    nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
-    nullableArray: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).nullableArray),
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).field),
-    enum: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                switch a {
-                | #FIRST => "FIRST"
-                | #SECOND => "SECOND"
-                | #THIRD => "THIRD"
-                }
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).enum),
-    embeddedInput: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) =>
-                        Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).embeddedInput),
-    custom: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).custom),
-  }
-  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = inp => {
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_EmbeddedInput).field),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = (
+    inp => {
+      nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
+      nullableArray: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).nullableArray),
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).field),
+      enum: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  switch a {
+                  | #FIRST => "FIRST"
+                  | #SECOND => "SECOND"
+                  | #THIRD => "THIRD"
+                  }
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).enum),
+      embeddedInput: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) =>
+                          Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).embeddedInput),
+      custom: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).custom),
+    }: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput
+  )
+  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = (
+    inp => {
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_EmbeddedInput).field),
+    }: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectNonrecursiveInput = (
     ~nonNullableField,
@@ -315,96 +321,102 @@ more: scalarsInput(arg: $arg2)
     }
     {scalarsInput, more}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
-    arg2: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg2),
-  }
-  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = inp => {
-    nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
-    nullableArray: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) => Js.Nullable.return((a => a)(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).nullableArray),
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).field),
-    enum: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                switch a {
-                | #FIRST => "FIRST"
-                | #SECOND => "SECOND"
-                | #THIRD => "THIRD"
-                }
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).enum),
-    embeddedInput: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                Js.Array2.map(a, b =>
-                  (
-                    a =>
-                      switch a {
-                      | None => Js.Nullable.undefined
-                      | Some(b) =>
-                        Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
-                      }
-                  )(b)
-                )
-            )(b),
-          )
-        }
-    )((inp: t_variables_NonrecursiveInput).embeddedInput),
-    custom: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_NonrecursiveInput).custom),
-  }
-  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = inp => {
-    field: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_EmbeddedInput).field),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg),
+      arg2: (a => serializeInputObjectNonrecursiveInput(a))((inp: t_variables).arg2),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectNonrecursiveInput: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput = (
+    inp => {
+      nonNullableField: (a => a)((inp: t_variables_NonrecursiveInput).nonNullableField),
+      nullableArray: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) => Js.Nullable.return((a => a)(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).nullableArray),
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).field),
+      enum: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  switch a {
+                  | #FIRST => "FIRST"
+                  | #SECOND => "SECOND"
+                  | #THIRD => "THIRD"
+                  }
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).enum),
+      embeddedInput: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  Js.Array2.map(a, b =>
+                    (
+                      a =>
+                        switch a {
+                        | None => Js.Nullable.undefined
+                        | Some(b) =>
+                          Js.Nullable.return((a => serializeInputObjectEmbeddedInput(a))(b))
+                        }
+                    )(b)
+                  )
+              )(b),
+            )
+          }
+      )((inp: t_variables_NonrecursiveInput).embeddedInput),
+      custom: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_NonrecursiveInput).custom),
+    }: t_variables_NonrecursiveInput => Raw.t_variables_NonrecursiveInput
+  )
+  and serializeInputObjectEmbeddedInput: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput = (
+    inp => {
+      field: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_EmbeddedInput).field),
+    }: t_variables_EmbeddedInput => Raw.t_variables_EmbeddedInput
+  )
   let makeVariables = (~arg, ~arg2, ()): t_variables => {arg, arg2}
   and makeInputObjectNonrecursiveInput = (
     ~nonNullableField,

--- a/snapshot_tests/operations/expected/uncurried/generate/pokedexScalars.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/pokedexScalars.res.txt
@@ -101,22 +101,24 @@ name
     }
     {pokemon: pokemon}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    id: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).id),
-    name: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).name),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      id: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).id),
+      name: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).name),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~id=?, ~name=?, ()): t_variables => {id, name}
   let makeDefaultVariables = () => makeVariables()
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
@@ -226,22 +228,24 @@ name
     }
     {pokemon: pokemon}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    id: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).id),
-    name: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).name),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      id: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).id),
+      name: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).name),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (~id=?, ~name=?, ()): t_variables => {id, name}
   let makeDefaultVariables = () => makeVariables()
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"

--- a/snapshot_tests/operations/expected/uncurried/generate/record.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/record.res.txt
@@ -333,31 +333,27 @@ string
 int  
 }
 "
-    let parse = (
-      (value): t => {
-        string: {
-          let value = (value: Raw.t).string
-          value
-        },
-        int: {
-          let value = (value: Raw.t).int
-          value
-        },
-      }: Raw.t => t
-    )
-    let serialize = (
-      (value): Raw.t => {
-        let int = {
-          let value = (value: t).int
-          value
-        }
-        and string = {
-          let value = (value: t).string
-          value
-        }
-        {string, int}
-      }: t => Raw.t
-    )
+    let parse = (value): t => {
+      string: {
+        let value = (value: Raw.t).string
+        value
+      },
+      int: {
+        let value = (value: Raw.t).int
+        value
+      },
+    }
+    let serialize = (value): Raw.t => {
+      let int = {
+        let value = (value: t).int
+        value
+      }
+      and string = {
+        let value = (value: t).string
+        value
+      }
+      {string, int}
+    }
     let verifyArgsAndParse = (~fragmentName as _Fragment: [#Fragment], value: Raw.t) => parse(value)
     let verifyName = x => switch x {
     | #Fragment => ()
@@ -600,39 +596,35 @@ name
 barkVolume  
 }
 "
-    let parse = (
-      (value): t => {
-        __typename: {
-          let value = (value: Raw.t).__typename
-          value
-        },
-        name: {
-          let value = (value: Raw.t).name
-          value
-        },
-        barkVolume: {
-          let value = (value: Raw.t).barkVolume
-          value
-        },
-      }: Raw.t => t
-    )
-    let serialize = (
-      (value): Raw.t => {
-        let barkVolume = {
-          let value = (value: t).barkVolume
-          value
-        }
-        and name = {
-          let value = (value: t).name
-          value
-        }
-        and __typename = {
-          let value = (value: t).__typename
-          value
-        }
-        {__typename, name, barkVolume}
-      }: t => Raw.t
-    )
+    let parse = (value): t => {
+      __typename: {
+        let value = (value: Raw.t).__typename
+        value
+      },
+      name: {
+        let value = (value: Raw.t).name
+        value
+      },
+      barkVolume: {
+        let value = (value: Raw.t).barkVolume
+        value
+      },
+    }
+    let serialize = (value): Raw.t => {
+      let barkVolume = {
+        let value = (value: t).barkVolume
+        value
+      }
+      and name = {
+        let value = (value: t).name
+        value
+      }
+      and __typename = {
+        let value = (value: t).__typename
+        value
+      }
+      {__typename, name, barkVolume}
+    }
     let verifyArgsAndParse = (~fragmentName as _DogFragment: [#DogFragment], value: Raw.t) =>
       parse(value)
     let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/uncurried/generate/recursiveInput.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/recursiveInput.res.txt
@@ -69,42 +69,46 @@ recursiveInput(arg: $arg)
     }
     {recursiveInput: recursiveInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectRecursiveInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectRecursiveInput: t_variables_RecursiveInput => Raw.t_variables_RecursiveInput = inp => {
-    otherField: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_RecursiveInput).otherField),
-    inner: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => serializeInputObjectRecursiveInput(a))(b))
-        }
-    )((inp: t_variables_RecursiveInput).inner),
-    enum: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) =>
-          Js.Nullable.return(
-            (
-              a =>
-                switch a {
-                | #FIRST => "FIRST"
-                | #SECOND => "SECOND"
-                | #THIRD => "THIRD"
-                }
-            )(b),
-          )
-        }
-    )((inp: t_variables_RecursiveInput).enum),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectRecursiveInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectRecursiveInput: t_variables_RecursiveInput => Raw.t_variables_RecursiveInput = (
+    inp => {
+      otherField: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_RecursiveInput).otherField),
+      inner: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => serializeInputObjectRecursiveInput(a))(b))
+          }
+      )((inp: t_variables_RecursiveInput).inner),
+      enum: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) =>
+            Js.Nullable.return(
+              (
+                a =>
+                  switch a {
+                  | #FIRST => "FIRST"
+                  | #SECOND => "SECOND"
+                  | #THIRD => "THIRD"
+                  }
+              )(b),
+            )
+          }
+      )((inp: t_variables_RecursiveInput).enum),
+    }: t_variables_RecursiveInput => Raw.t_variables_RecursiveInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectRecursiveInput = (
     ~otherField=?,
@@ -200,37 +204,45 @@ recursiveRepro(input: $input)
     }
     {recursiveRepro: recursiveRepro}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    input: (a => serializeInputObjectproblem_input(a))((inp: t_variables).input),
-  }
-  and serializeInputObjectproblem_input: t_variables_problem_input => Raw.t_variables_problem_input = inp => {
-    the_problem: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => serializeInputObjectthis_will_be_duplicated(a))(b))
-        }
-    )((inp: t_variables_problem_input).the_problem),
-    b: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => serializeInputObjectnested_type(a))(b))
-        }
-    )((inp: t_variables_problem_input).b),
-  }
-  and serializeInputObjectthis_will_be_duplicated: t_variables_this_will_be_duplicated => Raw.t_variables_this_will_be_duplicated = inp => {
-    id: (a => a)((inp: t_variables_this_will_be_duplicated).id),
-  }
-  and serializeInputObjectnested_type: t_variables_nested_type => Raw.t_variables_nested_type = inp => {
-    the_problem: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => serializeInputObjectthis_will_be_duplicated(a))(b))
-        }
-    )((inp: t_variables_nested_type).the_problem),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      input: (a => serializeInputObjectproblem_input(a))((inp: t_variables).input),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectproblem_input: t_variables_problem_input => Raw.t_variables_problem_input = (
+    inp => {
+      the_problem: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => serializeInputObjectthis_will_be_duplicated(a))(b))
+          }
+      )((inp: t_variables_problem_input).the_problem),
+      b: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => serializeInputObjectnested_type(a))(b))
+          }
+      )((inp: t_variables_problem_input).b),
+    }: t_variables_problem_input => Raw.t_variables_problem_input
+  )
+  and serializeInputObjectthis_will_be_duplicated: t_variables_this_will_be_duplicated => Raw.t_variables_this_will_be_duplicated = (
+    inp => {
+      id: (a => a)((inp: t_variables_this_will_be_duplicated).id),
+    }: t_variables_this_will_be_duplicated => Raw.t_variables_this_will_be_duplicated
+  )
+  and serializeInputObjectnested_type: t_variables_nested_type => Raw.t_variables_nested_type = (
+    inp => {
+      the_problem: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => serializeInputObjectthis_will_be_duplicated(a))(b))
+          }
+      )((inp: t_variables_nested_type).the_problem),
+    }: t_variables_nested_type => Raw.t_variables_nested_type
+  )
   let makeVariables = (~input, ()): t_variables => {input: input}
   and makeInputObjectproblem_input = (~the_problem=?, ~b=?, ()): t_variables_problem_input => {
     the_problem,

--- a/snapshot_tests/operations/expected/uncurried/generate/scalarsArgs.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/scalarsArgs.res.txt
@@ -98,48 +98,50 @@ scalarsInput(arg: {nullableString: $nullableString, string: $string, nullableInt
     }
     {scalarsInput: scalarsInput}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    nullableString: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableString),
-    string: (a => a)((inp: t_variables).string),
-    nullableInt: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableInt),
-    int: (a => a)((inp: t_variables).int),
-    nullableFloat: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableFloat),
-    float: (a => a)((inp: t_variables).float),
-    nullableBoolean: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableBoolean),
-    boolean: (a => a)((inp: t_variables).boolean),
-    nullableID: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables).nullableID),
-    id: (a => a)((inp: t_variables).id),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      nullableString: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableString),
+      string: (a => a)((inp: t_variables).string),
+      nullableInt: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableInt),
+      int: (a => a)((inp: t_variables).int),
+      nullableFloat: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableFloat),
+      float: (a => a)((inp: t_variables).float),
+      nullableBoolean: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableBoolean),
+      boolean: (a => a)((inp: t_variables).boolean),
+      nullableID: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables).nullableID),
+      id: (a => a)((inp: t_variables).id),
+    }: t_variables => Raw.t_variables
+  )
   let makeVariables = (
     ~nullableString=?,
     ~string,

--- a/snapshot_tests/operations/expected/uncurried/generate/scalarsInput.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/scalarsInput.res.txt
@@ -104,51 +104,55 @@ scalarsInput(arg: $arg)
     }
     {scalarsInput: scalarsInput}
   }
-  let rec serializeVariables: t_variables => Raw.t_variables = inp => {
-    arg: (a => serializeInputObjectVariousScalarsInput(a))((inp: t_variables).arg),
-  }
-  and serializeInputObjectVariousScalarsInput: t_variables_VariousScalarsInput => Raw.t_variables_VariousScalarsInput = inp => {
-    nullableString: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableString),
-    string: (a => a)((inp: t_variables_VariousScalarsInput).string),
-    nullableInt: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableInt),
-    int: (a => a)((inp: t_variables_VariousScalarsInput).int),
-    nullableFloat: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableFloat),
-    float: (a => a)((inp: t_variables_VariousScalarsInput).float),
-    nullableBoolean: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableBoolean),
-    boolean: (a => a)((inp: t_variables_VariousScalarsInput).boolean),
-    nullableID: (
-      a =>
-        switch a {
-        | None => Js.Nullable.undefined
-        | Some(b) => Js.Nullable.return((a => a)(b))
-        }
-    )((inp: t_variables_VariousScalarsInput).nullableID),
-    id: (a => a)((inp: t_variables_VariousScalarsInput).id),
-  }
+  let rec serializeVariables: t_variables => Raw.t_variables = (
+    inp => {
+      arg: (a => serializeInputObjectVariousScalarsInput(a))((inp: t_variables).arg),
+    }: t_variables => Raw.t_variables
+  )
+  and serializeInputObjectVariousScalarsInput: t_variables_VariousScalarsInput => Raw.t_variables_VariousScalarsInput = (
+    inp => {
+      nullableString: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableString),
+      string: (a => a)((inp: t_variables_VariousScalarsInput).string),
+      nullableInt: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableInt),
+      int: (a => a)((inp: t_variables_VariousScalarsInput).int),
+      nullableFloat: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableFloat),
+      float: (a => a)((inp: t_variables_VariousScalarsInput).float),
+      nullableBoolean: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableBoolean),
+      boolean: (a => a)((inp: t_variables_VariousScalarsInput).boolean),
+      nullableID: (
+        a =>
+          switch a {
+          | None => Js.Nullable.undefined
+          | Some(b) => Js.Nullable.return((a => a)(b))
+          }
+      )((inp: t_variables_VariousScalarsInput).nullableID),
+      id: (a => a)((inp: t_variables_VariousScalarsInput).id),
+    }: t_variables_VariousScalarsInput => Raw.t_variables_VariousScalarsInput
+  )
   let makeVariables = (~arg, ()): t_variables => {arg: arg}
   and makeInputObjectVariousScalarsInput = (
     ~nullableString=?,

--- a/snapshot_tests/operations/expected/uncurried/generate/skipDirectives.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/skipDirectives.res.txt
@@ -164,9 +164,9 @@ string @include(if: $var)
     }
     {v1, v2}
   }
-  let serializeVariables: t_variables => Raw.t_variables = inp => {
-    var: (a => a)((inp: t_variables).var),
-  }
+  let serializeVariables: t_variables => Raw.t_variables = (
+    inp => {var: (a => a)((inp: t_variables).var)}: t_variables => Raw.t_variables
+  )
   let makeVariables = (~var, ()): t_variables => {var: var}
   external unsafe_fromJson: Js.Json.t => Raw.t = "%identity"
   external toJson: Raw.t => Js.Json.t = "%identity"

--- a/snapshot_tests/operations/expected/uncurried/generate/tagged_template.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/tagged_template.res.txt
@@ -1545,59 +1545,55 @@ nullableOfNonNullable
     ],
     [],
   )
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment: [#ListFragment], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {
@@ -1847,59 +1843,55 @@ nullableOfNonNullable
     ],
     [],
   )
-  let parse = (
-    (value): t => {
-      nullableOfNullable: {
-        let value = (value: Raw.t).nullableOfNullable
-        switch Js.toOption(value) {
-        | Some(value) =>
-          Some(
-            Js.Array2.map(value, value =>
-              switch Js.toOption(value) {
-              | Some(value) => Some(value)
-              | None => None
-              }
-            ),
-          )
-        | None => None
-        }
-      },
-      nullableOfNonNullable: {
-        let value = (value: Raw.t).nullableOfNonNullable
-        switch Js.toOption(value) {
-        | Some(value) => Some(Js.Array2.map(value, value => value))
-        | None => None
-        }
-      },
-    }: Raw.t => t
-  )
-  let serialize = (
-    (value): Raw.t => {
-      let nullableOfNonNullable = {
-        let value = (value: t).nullableOfNonNullable
-        switch value {
-        | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
-        | None => Js.Nullable.null
-        }
+  let parse = (value): t => {
+    nullableOfNullable: {
+      let value = (value: Raw.t).nullableOfNullable
+      switch Js.toOption(value) {
+      | Some(value) =>
+        Some(
+          Js.Array2.map(value, value =>
+            switch Js.toOption(value) {
+            | Some(value) => Some(value)
+            | None => None
+            }
+          ),
+        )
+      | None => None
       }
-      and nullableOfNullable = {
-        let value = (value: t).nullableOfNullable
-        switch value {
-        | Some(value) =>
-          Js.Nullable.return(
-            Js.Array2.map(value, value =>
-              switch value {
-              | Some(value) => Js.Nullable.return(value)
-              | None => Js.Nullable.null
-              }
-            ),
-          )
-        | None => Js.Nullable.null
-        }
+    },
+    nullableOfNonNullable: {
+      let value = (value: Raw.t).nullableOfNonNullable
+      switch Js.toOption(value) {
+      | Some(value) => Some(Js.Array2.map(value, value => value))
+      | None => None
       }
-      {nullableOfNullable, nullableOfNonNullable}
-    }: t => Raw.t
-  )
+    },
+  }
+  let serialize = (value): Raw.t => {
+    let nullableOfNonNullable = {
+      let value = (value: t).nullableOfNonNullable
+      switch value {
+      | Some(value) => Js.Nullable.return(Js.Array2.map(value, value => value))
+      | None => Js.Nullable.null
+      }
+    }
+    and nullableOfNullable = {
+      let value = (value: t).nullableOfNullable
+      switch value {
+      | Some(value) =>
+        Js.Nullable.return(
+          Js.Array2.map(value, value =>
+            switch value {
+            | Some(value) => Js.Nullable.return(value)
+            | None => Js.Nullable.null
+            }
+          ),
+        )
+      | None => Js.Nullable.null
+      }
+    }
+    {nullableOfNullable, nullableOfNonNullable}
+  }
   let verifyArgsAndParse = (~fragmentName as _ListFragment8: [#ListFragment8], value: Raw.t) =>
     parse(value)
   let verifyName = x => switch x {

--- a/snapshot_tests/operations/expected/uncurried/generate/union.res.txt
+++ b/snapshot_tests/operations/expected/uncurried/generate/union.res.txt
@@ -541,31 +541,27 @@ name
 __typename  
 }
 "
-    let parse = (
-      (value): named => {
-        name: {
-          let value = (value: Raw.t).name
-          value
-        },
-        __typename: {
-          let value = (value: Raw.t).__typename
-          value
-        },
-      }: Raw.t => named
-    )
-    let serialize = (
-      (value): Raw.t => {
-        let __typename = {
-          let value = (value: named).__typename
-          value
-        }
-        and name = {
-          let value = (value: named).name
-          value
-        }
-        {name, __typename}
-      }: named => Raw.t
-    )
+    let parse = (value): named => {
+      name: {
+        let value = (value: Raw.t).name
+        value
+      },
+      __typename: {
+        let value = (value: Raw.t).__typename
+        value
+      },
+    }
+    let serialize = (value): Raw.t => {
+      let __typename = {
+        let value = (value: named).__typename
+        value
+      }
+      and name = {
+        let value = (value: named).name
+        value
+      }
+      {name, __typename}
+    }
     let verifyArgsAndParse = (~fragmentName as _DogFields: [#DogFields], value: Raw.t) =>
       parse(value)
     let verifyName = x => switch x {

--- a/src/graphql_compiler/graphql_parser_schema.ml
+++ b/src/graphql_compiler/graphql_parser_schema.ml
@@ -129,17 +129,16 @@ let parse_enum ~description parser =
          | { item = Graphql_lexer.String description } -> (
            let _ = next parser in
            match parse_enum_value ~description:(Some description) parser with
-           | Ok value -> consume_enums (value :: acc)
+           | Ok value -> (consume_enums [@tailcall]) (value :: acc)
            | Error e -> Error e)
          | { item = Graphql_lexer.Name _ } -> (
            match parse_enum_value ~description:None parser with
-           | Ok value -> consume_enums (value :: acc)
+           | Ok value -> (consume_enums [@tailcall]) (value :: acc)
            | Error e -> Error e)
          | { item = Graphql_lexer.Curly_close } ->
            let _ = next parser in
            Ok (List.rev acc)
          | { item; span } -> Error { span; item = Unexpected_token item }
-         [@@tailcall]
        in
        let em_values = consume_enums [] in
        em_values
@@ -290,10 +289,9 @@ let rec parse_union_types ?(acc = []) parser =
   match (acc, pipe) with
   | _, Ok (Some _) | [], Ok None -> (
     match expect_name parser with
-    | Ok union -> parse_union_types ~acc:(union.item :: acc) parser
+    | Ok union -> (parse_union_types [@tailcall]) ~acc:(union.item :: acc) parser
     | Error e -> Error e)
   | _, _ -> Ok (List.rev acc)
-  [@@tailcall]
 
 let parse_union ~description parser =
   expect_name parser

--- a/src/ppx/output_module.ml
+++ b/src/ppx/output_module.ml
@@ -901,14 +901,16 @@ let generate_fragment_signature config name variable_definitions _has_error
                 | (_, Some _, _), Some return_type ->
                   return_type
                 | _ -> "string")]
-            [@@ocaml.doc " the GraphQL fragment "]];
-        [%sigi:
-          val parse : Raw.t -> [%t type_name]
+          [@@ocaml.doc " the GraphQL fragment "]];
+        wrap_sig_uncurried_fn
+          [%sigi:
+            val parse : Raw.t -> [%t type_name]
             [@@ocaml.doc
               " Parse the raw JSON-compatible GraphQL data into ReasonML data \
                types "]];
-        [%sigi:
-          val serialize : [%t type_name] -> Raw.t
+        wrap_sig_uncurried_fn
+          [%sigi:
+            val serialize : [%t type_name] -> Raw.t
             [@@ocaml.doc
               " Serialize the ReasonML GraphQL data that was parsed using the \
                parse\n\
@@ -1015,7 +1017,6 @@ let generate_fragment_implementation config name
              None);
       ]
   in
-  let type_name = base_type_name (Option.get_or_else "t" type_name) in
   let contents =
     [
       [ [%stri [@@@ocaml.warning "-32-30"]] ];
@@ -1024,13 +1025,8 @@ let generate_fragment_implementation config name
       graphql_external config (Graphql_ast.Fragment fragment);
       [
         [%stri let query = [%e printed_query]];
-        wrap_as_uncurried_fn
-          [%stri
-            let parse = (fun value -> [%e parse_fn] : Raw.t -> [%t type_name])];
-        wrap_as_uncurried_fn
-          [%stri
-            let serialize =
-              (fun value -> [%e serialize_fn] : [%t type_name] -> Raw.t)];
+        wrap_as_uncurried_fn [%stri let parse value = [%e parse_fn]];
+        wrap_as_uncurried_fn [%stri let serialize value = [%e serialize_fn]];
       ];
       [
         [%stri let verifyArgsAndParse = [%e verify_parse]];


### PR DESCRIPTION
resolves #296

the module signature was not wrapped, and the implementation was wrapped in another fun that prevented the match in wrap_as_uncurried_fn from working as intended

I also fixed a warning 53 with the @@tailcall attribute I was getting for ocaml 5.1.1, maybe I ended up with different versions of something?